### PR TITLE
Add transformation of exceptions to JSON responses

### DIFF
--- a/src/Controller/CatchAllController.php
+++ b/src/Controller/CatchAllController.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Handles exceptions for routes unavailable within OpenAPI specifications.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class CatchAllController extends Controller
+{
+    /**
+     * The routing reference to this controller.
+     *
+     * @var string
+     */
+    public const CONTROLLER_REFERENCE = 'nijens_openapi.controller.catch_all::throwNoRouteException';
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * Constructs a new CatchAllController instance.
+     *
+     * @param RouterInterface $router
+     */
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * Throws a NotFoundHttpException or MethodNotAllowedException when this controller action is reached.
+     *
+     * @param Request $request
+     *
+     * @throws NotFoundHttpException         when the route could not be found
+     * @throws MethodNotAllowedHttpException when the route was found but the request method is not allowed
+     */
+    public function throwNoRouteException(Request $request)
+    {
+        $exceptionMessage = sprintf("No route found for '%s %s'.", $request->getMethod(), $request->getPathInfo());
+        $exception = new NotFoundHttpException($exceptionMessage);
+
+        try {
+            $urlMatcher = $this->createUrlMatcher();
+            $urlMatcher->match($request->getPathInfo());
+        } catch (ResourceNotFoundException $exception) {
+            $exception = new NotFoundHttpException($exceptionMessage, $exception);
+        } catch (MethodNotAllowedException $exception) {
+            $exceptionMessage = sprintf(
+                "No route found for '%s %s': Method Not Allowed (Allowed: %s).",
+                $request->getMethod(),
+                $request->getPathInfo(),
+                implode(', ', $exception->getAllowedMethods())
+            );
+
+            $exception = new MethodNotAllowedHttpException(
+                $exception->getAllowedMethods(),
+                $exceptionMessage,
+                $exception
+            );
+        }
+
+        throw $exception;
+    }
+
+    /**
+     * Returns a new URL matcher to match the request with existing API routes.
+     *
+     * @return UrlMatcherInterface
+     */
+    private function createUrlMatcher(): UrlMatcherInterface
+    {
+        return new UrlMatcher(
+            $this->getUrlMatcherRouteCollection(),
+            $this->router->getContext()
+        );
+    }
+
+    /**
+     * Returns a RouteCollection cloned from the router with the 'catch-all' route removed.
+     *
+     * @return RouteCollection
+     */
+    private function getUrlMatcherRouteCollection(): RouteCollection
+    {
+        $routeCollection = clone $this->router->getRouteCollection();
+        foreach ($routeCollection as $routeName => $route) {
+            if ($route->getDefault('_controller') !== self::CONTROLLER_REFERENCE) {
+                continue;
+            }
+
+            $routeCollection->remove($routeName);
+        }
+
+        return $routeCollection;
+    }
+}

--- a/src/EventListener/JsonResponseExceptionSubscriber.php
+++ b/src/EventListener/JsonResponseExceptionSubscriber.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\EventListener;
+
+use Nijens\OpenapiBundle\Exception\HttpExceptionInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Transforms an exception to a JSON response for OpenAPI routes.
+ */
+class JsonResponseExceptionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * The boolean indicating if the kernel is in debug mode.
+     *
+     * @var bool
+     */
+    private $debugMode;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return array(
+            KernelEvents::EXCEPTION => array(
+                array('onKernelExceptionTransformToJsonResponse', 0),
+            ),
+        );
+    }
+
+    /**
+     * Constructs a new JsonResponseExceptionSubscriber instance.
+     *
+     * @param RouterInterface $router
+     * @param bool            $debugMode
+     */
+    public function __construct(RouterInterface $router, bool $debugMode)
+    {
+        $this->router = $router;
+        $this->debugMode = $debugMode;
+    }
+
+    /**
+     * Converts the exception to a JSON response.
+     *
+     * @param GetResponseForExceptionEvent $event
+     */
+    public function onKernelExceptionTransformToJsonResponse(GetResponseForExceptionEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        $route = $this->router->getRouteCollection()->get(
+            $request->attributes->get('_route')
+        );
+
+        if ($route instanceof Route === false || $route->hasOption('openapi_resource') === false) {
+            return;
+        }
+
+        $response = new JsonResponse();
+
+        $statusCode = JsonResponse::HTTP_INTERNAL_SERVER_ERROR;
+        $message = 'Unexpected error.';
+
+        $exception = $event->getException();
+        if ($exception instanceof HttpException) {
+            $statusCode = $exception->getStatusCode();
+        }
+
+        if ($this->debugMode || $exception instanceof HttpException) {
+            $message = $exception->getMessage();
+        }
+
+        $responseBody = array('message' => $message);
+        if ($exception instanceof HttpExceptionInterface) {
+            $responseBody['errors'] = $exception->getErrors();
+        }
+
+        $response->setStatusCode($statusCode);
+        $response->setData($responseBody);
+
+        $event->setResponse($response);
+    }
+}

--- a/src/Exception/BadJsonRequestHttpException.php
+++ b/src/Exception/BadJsonRequestHttpException.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Exception;
+
+use Exception;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * BadJsonRequestHttpException.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class BadJsonRequestHttpException extends BadRequestHttpException implements HttpExceptionInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrors(): array
+    {
+        $errors = array();
+
+        $previousException = $this->getPrevious();
+        if ($previousException instanceof Exception) {
+            $errors[] = $previousException->getMessage();
+        }
+
+        return $errors;
+    }
+}

--- a/src/Exception/HttpExceptionInterface.php
+++ b/src/Exception/HttpExceptionInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Exception;
+
+/**
+ * HttpExceptionInterface.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+interface HttpExceptionInterface
+{
+    /**
+     * Returns the list of errors.
+     *
+     * @return array
+     */
+    public function getErrors(): array;
+}

--- a/src/Exception/InvalidRequestHttpException.php
+++ b/src/Exception/InvalidRequestHttpException.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
  *
  * @author Niels Nijens <nijens.niels@gmail.com>
  */
-class InvalidRequestHttpException extends UnprocessableEntityHttpException
+class InvalidRequestHttpException extends UnprocessableEntityHttpException implements HttpExceptionInterface
 {
     /**
      * The list with errors resulting in this exception.
@@ -32,15 +32,13 @@ class InvalidRequestHttpException extends UnprocessableEntityHttpException
      *
      * @param array $errors
      */
-    public function setErrors(array $errors)
+    public function setErrors(array $errors): void
     {
         $this->errors = $errors;
     }
 
     /**
-     * Returns the list of errors.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getErrors(): array
     {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -12,6 +12,7 @@
         <parameter key="nijens_openapi.json.schema_loader.class">Nijens\OpenapiBundle\Json\SchemaLoader</parameter>
         <parameter key="nijens_openapi.json.validator.class">JsonSchema\Validator</parameter>
         <parameter key="nijens_openapi.event_subscriber.json_request_body_validation.class">Nijens\OpenapiBundle\EventListener\JsonRequestBodyValidationSubscriber</parameter>
+        <parameter key="nijens_openapi.event_subscriber.json_response_exception.class">Nijens\OpenapiBundle\EventListener\JsonResponseExceptionSubscriber</parameter>
     </parameters>
 
     <services>
@@ -48,6 +49,13 @@
             <argument type="service" id="nijens_openapi.json.parser"/>
             <argument type="service" id="nijens_openapi.json.schema_loader"/>
             <argument type="service" id="nijens_openapi.json.validator"/>
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="nijens_openapi.event_subscriber.json_response_exception" class="%nijens_openapi.event_subscriber.json_response_exception.class%">
+            <argument type="service" id="router"/>
+            <argument>%kernel.debug%</argument>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -4,6 +4,7 @@
            xsi:schemaLocation='http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd'>
 
     <parameters>
+        <parameter key="nijens_openapi.controller.catch_all.class">Nijens\OpenapiBundle\Controller\CatchAllController</parameter>
         <parameter key="nijens_openapi.routing.loader.class">Nijens\OpenapiBundle\Routing\RouteLoader</parameter>
         <parameter key="nijens_openapi.json.parser.class">Seld\JsonLint\JsonParser</parameter>
         <parameter key="nijens_openapi.json.dereferencer.class">League\JsonReference\Dereferencer</parameter>
@@ -14,6 +15,12 @@
     </parameters>
 
     <services>
+        <service id="nijens_openapi.controller.catch_all" class="%nijens_openapi.controller.catch_all.class%">
+            <argument type="service" id="router"/>
+
+            <tag name="controller.service_arguments"/>
+        </service>
+
         <service id="nijens_openapi.routing.loader" class="%nijens_openapi.routing.loader.class%">
             <argument type="service" id="nijens_openapi.json.schema_loader"/>
 

--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -11,6 +11,7 @@
 
 namespace Nijens\OpenapiBundle\Routing;
 
+use Nijens\OpenapiBundle\Controller\CatchAllController;
 use Nijens\OpenapiBundle\Json\JsonPointer;
 use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
 use stdClass;
@@ -69,6 +70,8 @@ class RouteLoader extends Loader
         foreach ($paths as $path => $pathItem) {
             $this->parsePathItem($jsonPointer, $resource, $routeCollection, $path, $pathItem);
         }
+
+        $this->addDefaultRoutes($routeCollection, $resource);
 
         return $routeCollection;
     }
@@ -182,5 +185,23 @@ class RouteLoader extends Loader
             trim(preg_replace('/[^a-zA-Z0-9]+/', '_', $path), '_'),
             $requestMethod
         );
+    }
+
+    /**
+     * Adds a catch-all route to handle responses for non-existing routes.
+     *
+     * @param RouteCollection $collection
+     * @param string          $resource
+     */
+    private function addDefaultRoutes(RouteCollection $collection, string $resource)
+    {
+        $catchAllRoute = new Route(
+            '/{catchall}',
+            array('_controller' => CatchAllController::CONTROLLER_REFERENCE),
+            array('catchall' => '.+'),
+            array('openapi_resource' => $resource)
+        );
+
+        $collection->add('catch_all', $catchAllRoute);
     }
 }

--- a/tests/Controller/CatchAllControllerTest.php
+++ b/tests/Controller/CatchAllControllerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Controller;
+
+use Nijens\OpenapiBundle\Controller\CatchAllController;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * CatchAllControllerTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class CatchAllControllerTest extends TestCase
+{
+    /**
+     * @var CatchAllController
+     */
+    private $controller;
+
+    /**
+     * @var RouteCollection
+     */
+    private $routeCollection;
+
+    /**
+     * @var MockObject
+     */
+    private $routerMock;
+
+    /**
+     * Creates a new CatchAllController instance for testing.
+     */
+    protected function setUp()
+    {
+        $routeOptions = array('openapi_resource' => 'openapi.json');
+
+        $this->routeCollection = new RouteCollection();
+        $this->routeCollection->add(
+            'test',
+            new Route(
+                '/test',
+                array(),
+                array(),
+                $routeOptions,
+                '',
+                array(),
+                array(Request::METHOD_GET)
+            )
+        );
+        $this->routeCollection->add(
+            'catch_all',
+            new Route(
+                '/{catchall}',
+                array('_controller' => CatchAllController::CONTROLLER_REFERENCE),
+                array('catchall' => '.+'),
+                $routeOptions
+            )
+        );
+
+        $this->routerMock = $this->getMockBuilder(RouterInterface::class)
+            ->getMock();
+        $this->routerMock->expects($this->any())
+            ->method('getRouteCollection')
+            ->willReturn($this->routeCollection);
+
+        $this->controller = new CatchAllController($this->routerMock);
+    }
+
+    /**
+     * Tests if constructing a new CatchAllController instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame($this->routerMock, 'router', $this->controller);
+    }
+
+    /**
+     * Tests if CatchAllController::throwNoRouteException throws a NotFoundHttpException
+     * when no route is found.
+     *
+     * @depends testConstruct
+     */
+    public function testThrowNoRouteExceptionThrowsNotFoundHttpException()
+    {
+        $this->routerMock->expects($this->once())
+            ->method('getContext')
+            ->willReturn(new RequestContext());
+
+        $requestMock = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $requestMock->expects($this->once())
+            ->method('getMethod')
+            ->willReturn(Request::METHOD_GET);
+        $requestMock->expects($this->exactly(2))
+            ->method('getPathInfo')
+            ->willReturn('/does-not-exist');
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage("No route found for 'GET /does-not-exist'.");
+
+        $this->controller->throwNoRouteException($requestMock);
+    }
+
+    /**
+     * Tests if CatchAllController::throwNoRouteException throws a MethodNotAllowedHttpException
+     * when a route is found but the request method is not allowed.
+     *
+     * @depends testThrowNoRouteExceptionThrowsNotFoundHttpException
+     */
+    public function testThrowNoRouteExceptionThrowsMethodNotAllowedHttpException()
+    {
+        $requestContext = new RequestContext('', Request::METHOD_POST);
+        $requestContext->setPathInfo('/test');
+
+        $this->routerMock->expects($this->once())
+            ->method('getContext')
+            ->willReturn($requestContext);
+
+        $requestMock = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $requestMock->expects($this->exactly(2))
+            ->method('getMethod')
+            ->willReturn(Request::METHOD_POST);
+        $requestMock->expects($this->exactly(3))
+            ->method('getPathInfo')
+            ->willReturn('/test');
+
+        $this->expectException(MethodNotAllowedHttpException::class);
+        $this->expectExceptionMessage("No route found for 'POST /test': Method Not Allowed (Allowed: GET).");
+
+        $this->controller->throwNoRouteException($requestMock);
+    }
+
+    /**
+     * Tests if CatchAllController::throwNoRouteException retains the routes in the original RouteCollection.
+     */
+    public function testThrowNoRouteExceptionRetrainsTheOriginalRouteCollection()
+    {
+        $this->routerMock->expects($this->once())
+            ->method('getContext')
+            ->willReturn(new RequestContext());
+
+        $requestMock = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $requestMock->expects($this->once())
+            ->method('getMethod')
+            ->willReturn(Request::METHOD_GET);
+        $requestMock->expects($this->exactly(2))
+            ->method('getPathInfo')
+            ->willReturn('/does-not-exist');
+
+        try {
+            $this->controller->throwNoRouteException($requestMock);
+            $this->fail();
+        } catch (NotFoundHttpException | MethodNotAllowedHttpException $exception) {
+        }
+
+        $this->assertCount(2, $this->routeCollection);
+    }
+}

--- a/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
+++ b/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
@@ -15,6 +15,7 @@ use JsonSchema\Validator;
 use League\JsonReference\Dereferencer;
 use League\JsonReference\ReferenceSerializer\InlineReferenceSerializer;
 use Nijens\OpenapiBundle\EventListener\JsonRequestBodyValidationSubscriber;
+use Nijens\OpenapiBundle\Exception\BadJsonRequestHttpException;
 use Nijens\OpenapiBundle\Exception\InvalidRequestHttpException;
 use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -211,8 +212,8 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $event = new GetResponseEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
 
-        $this->expectException(InvalidRequestHttpException::class);
-        $this->expectExceptionMessage('The request body should be valid JSON.');
+        $this->expectException(BadJsonRequestHttpException::class);
+        $this->expectExceptionMessage("The request content-type should be 'application/json'.");
 
         $this->subscriber->validateRequestBody($event);
     }
@@ -253,7 +254,7 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $event = new GetResponseEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
 
-        $this->expectException(InvalidRequestHttpException::class);
+        $this->expectException(BadJsonRequestHttpException::class);
         $this->expectExceptionMessage('The request body should be valid JSON.');
 
         try {

--- a/tests/EventListener/JsonResponseExceptionSubscriberTest.php
+++ b/tests/EventListener/JsonResponseExceptionSubscriberTest.php
@@ -1,0 +1,287 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\EventListener;
+
+use Exception;
+use Nijens\OpenapiBundle\EventListener\JsonResponseExceptionSubscriber;
+use Nijens\OpenapiBundle\Exception\BadJsonRequestHttpException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * JsonResponseExceptionSubscriberTest.
+ */
+class JsonResponseExceptionSubscriberTest extends TestCase
+{
+    /**
+     * @var JsonResponseExceptionSubscriber
+     */
+    private $subscriber;
+
+    /**
+     * @var MockObject
+     */
+    private $routerMock;
+
+    /**
+     * Creates a new JsonResponseExceptionSubscriber instance for testing.
+     */
+    protected function setUp()
+    {
+        $this->routerMock = $this->getMockBuilder(RouterInterface::class)
+            ->getMock();
+
+        $this->subscriber = new JsonResponseExceptionSubscriber($this->routerMock, false);
+    }
+
+    /**
+     * Tests if JsonResponseExceptionSubscriber::getSubscribedEvents returns the list with expected listeners.
+     */
+    public function testGetSubscribedEvents()
+    {
+        $subscribedEvents = JsonResponseExceptionSubscriber::getSubscribedEvents();
+
+        $this->assertSame(
+            array(
+                KernelEvents::EXCEPTION => array(
+                    array('onKernelExceptionTransformToJsonResponse', 0),
+                ),
+            ),
+            $subscribedEvents
+        );
+    }
+
+    /**
+     * Tests if constructing a new JsonResponseExceptionSubscriber instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame($this->routerMock, 'router', $this->subscriber);
+        $this->assertAttributeSame(false, 'debugMode', $this->subscriber);
+    }
+
+    /**
+     * Tests if JsonResponseExceptionSubscriber::onKernelExceptionTransformToJsonResponse
+     * sets no response on the event when no Route is found in the RouteCollection.
+     *
+     * @depends testConstruct
+     */
+    public function testOnKernelExceptionTransformToJsonResponseDoesNothingWhenRouteIsNotFoundInCollection()
+    {
+        $routeCollection = new RouteCollection();
+
+        $this->routerMock->expects($this->once())
+            ->method('getRouteCollection')
+            ->willReturn($routeCollection);
+
+        $request = new Request();
+        $request->attributes->set('_route', 'not_in_collection');
+
+        $eventMock = $this->getMockBuilder(GetResponseForExceptionEvent::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getRequest'))
+            ->getMock();
+        $eventMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($request);
+
+        $this->subscriber->onKernelExceptionTransformToJsonResponse($eventMock);
+
+        $this->assertNull($eventMock->getResponse());
+    }
+
+    /**
+     * Tests if JsonResponseExceptionSubscriber::onKernelExceptionTransformToJsonResponse
+     * sets no response on the event when the Route does not have the 'openapi_resource' option set.
+     *
+     * @depends testConstruct
+     */
+    public function testOnKernelExceptionTransformToJsonResponseDoesNothingWhenRouteIsNotAnOpenapiRoute()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('no_openapi_route', new Route('/no-openapi-route'));
+
+        $this->routerMock->expects($this->once())
+            ->method('getRouteCollection')
+            ->willReturn($routeCollection);
+
+        $request = new Request();
+        $request->attributes->set('_route', 'no_openapi_route');
+
+        $eventMock = $this->getMockBuilder(GetResponseForExceptionEvent::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getRequest'))
+            ->getMock();
+        $eventMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($request);
+
+        $this->subscriber->onKernelExceptionTransformToJsonResponse($eventMock);
+
+        $this->assertNull($eventMock->getResponse());
+    }
+
+    /**
+     * Tests if JsonResponseExceptionSubscriber::onKernelExceptionTransformToJsonResponse
+     * sets a response with 'Unexpected error' message for non-http exceptions and not
+     * the actual error message, as that might expose private information.
+     *
+     * @depends testConstruct
+     */
+    public function testOnKernelExceptionTransformToJsonResponseSetsJsonResponseWithUnexpectedErrorMessage()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add(
+            'openapi_route',
+            new Route(
+                '/openapi-route',
+                array(),
+                array(),
+                array('openapi_resource' => 'openapi.json')
+            )
+        );
+
+        $this->routerMock->expects($this->once())
+            ->method('getRouteCollection')
+            ->willReturn($routeCollection);
+
+        $request = new Request();
+        $request->attributes->set('_route', 'openapi_route');
+
+        $eventMock = $this->getMockBuilder(GetResponseForExceptionEvent::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getRequest', 'getException'))
+            ->getMock();
+        $eventMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($request);
+        $eventMock->expects($this->once())
+            ->method('getException')
+            ->willReturn(new Exception('This message should not be visible.'));
+
+        $this->subscriber->onKernelExceptionTransformToJsonResponse($eventMock);
+
+        $response = $eventMock->getResponse();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(JsonResponse::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+        $this->assertSame('{"message":"Unexpected error."}', $response->getContent());
+    }
+
+    /**
+     * Tests if JsonResponseExceptionSubscriber::onKernelExceptionTransformToJsonResponse
+     * sets a response with the message and status of the http exception.
+     *
+     * @depends testConstruct
+     */
+    public function testOnKernelExceptionTransformToJsonResponseSetsJsonResponseWithExceptionMessage()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add(
+            'openapi_route',
+            new Route(
+                '/openapi-route',
+                array(),
+                array(),
+                array('openapi_resource' => 'openapi.json')
+            )
+        );
+
+        $this->routerMock->expects($this->once())
+            ->method('getRouteCollection')
+            ->willReturn($routeCollection);
+
+        $request = new Request();
+        $request->attributes->set('_route', 'openapi_route');
+
+        $eventMock = $this->getMockBuilder(GetResponseForExceptionEvent::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getRequest', 'getException'))
+            ->getMock();
+        $eventMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($request);
+        $eventMock->expects($this->once())
+            ->method('getException')
+            ->willReturn(
+                new BadJsonRequestHttpException(
+                    'This message should be visible.',
+                    new Exception('This previous exception message should be visible too.')
+                )
+            );
+
+        $this->subscriber->onKernelExceptionTransformToJsonResponse($eventMock);
+
+        $response = $eventMock->getResponse();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(JsonResponse::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame(
+            '{"message":"This message should be visible.","errors":["This previous exception message should be visible too."]}',
+            $response->getContent()
+        );
+    }
+
+    /**
+     * Tests if JsonResponseExceptionSubscriber::onKernelExceptionTransformToJsonResponse
+     * sets a response with the message of any exception when debug mode is active.
+     *
+     * @depends testConstruct
+     */
+    public function testOnKernelExceptionTransformToJsonResponseSetsJsonResponseWithExceptionMessageInDebugMode()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add(
+            'openapi_route',
+            new Route(
+                '/openapi-route',
+                array(),
+                array(),
+                array('openapi_resource' => 'openapi.json')
+            )
+        );
+
+        $this->routerMock->expects($this->once())
+            ->method('getRouteCollection')
+            ->willReturn($routeCollection);
+
+        $request = new Request();
+        $request->attributes->set('_route', 'openapi_route');
+
+        $eventMock = $this->getMockBuilder(GetResponseForExceptionEvent::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('getRequest', 'getException'))
+            ->getMock();
+        $eventMock->expects($this->once())
+            ->method('getRequest')
+            ->willReturn($request);
+        $eventMock->expects($this->once())
+            ->method('getException')
+            ->willReturn(new Exception('This message should be visible in debug mode.'));
+
+        $this->subscriber = new JsonResponseExceptionSubscriber($this->routerMock, true);
+        $this->subscriber->onKernelExceptionTransformToJsonResponse($eventMock);
+
+        $response = $eventMock->getResponse();
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(JsonResponse::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+        $this->assertSame('{"message":"This message should be visible in debug mode."}', $response->getContent());
+    }
+}


### PR DESCRIPTION
This PR includes:
* Improved differentiation between types of errors within the `JsonRequestBodyValidationSubscriber`.
* A controller to catch all requests to paths with unavailable routes to both be able to improve error messages and triggering the Symfony's security access control on all API paths.
* An exception subscriber to transform exception to readable JSON responses. With implementation to display additional information for the `BadJsonRequestHttpException` and `InvalidRequestHttpException`.

Closes #10.