### PR TITLE
Add capability to override exception responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,44 @@ A Symfony controller for a route is configured by adding the `x-symfony-controll
 
 The value of the `x-symfony-controller` property is the same as you would normally add to a [Symfony route](https://symfony.com/doc/current/routing.html#creating-routes).
 
+## Custom Error Handling
+
+The default error response template looks like:
+```json
+{
+    "message": "Validation of JSON request body failed.",
+    "errors": [
+        "The property iAmRequired is required",
+        "The property iAmExtra is not defined and the definition does not allow additional properties"
+    ]
+}
+```
+
+If your project requires a different formatting of the response or perhaps different response codes, the default
+response builder can be overridden. Following the ["How to Decorate Services" guide from Symfony](https://symfony.com/doc/current/service_container/service_decoration.html),
+you can define your own service which implements `ExceptionJsonResponseBuilderInterface` and handles the error response
+building instead of `nijens_openapi.service.exception_json_response_builder`. When validation against the schema fails,
+an exception will be thrown which implements `HttpExceptionInterface`. The `getErrors()` method will provide a
+multi-dimensional array similar to this:
+```php
+array(
+    array(
+        'property' => 'iAmRequired',
+        'pointer' => '/iAmRequired',
+        'message' => 'The property iAmRequired is required',
+        'constraint' => 'required',
+        'context' => 1,
+    ),
+    array(
+        'property' => '',
+        'pointer' => '',
+        'message' => 'The property iAmExtra is not defined and the definition does not allow additional properties',
+        'constraint' => 'additionalProp',
+        'context' => 1,
+    ),
+)
+```
+
 ## Credits and acknowledgements
 
 * Author: [Niels Nijens][link-author]

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "ext-json": "*",
         "justinrainbow/json-schema": "^5.2",
         "league/json-reference": "^1.1",
         "seld/jsonlint": "^1.7",
@@ -18,6 +19,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.11",
+        "matthiasnoback/symfony-dependency-injection-test": "^3.0",
         "php-coveralls/php-coveralls": "^2.1",
         "phpunit/phpunit": "^7.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07541bff514c6f7e3dc3bec68633bbe6",
+    "content-hash": "6b9769cb904aa7963fb8e22ae9a0e5ed",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -1819,6 +1819,114 @@
                 "url"
             ],
             "time": "2017-03-20T17:10:46+00:00"
+        },
+        {
+            "name": "matthiasnoback/symfony-config-test",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SymfonyTest/SymfonyConfigTest.git",
+                "reference": "d69210afc4aca99038d522f59ccf5074aff2f2e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SymfonyTest/SymfonyConfigTest/zipball/d69210afc4aca99038d522f59ccf5074aff2f2e1",
+                "reference": "d69210afc4aca99038d522f59ccf5074aff2f2e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "symfony/config": "^2.7 || ^3.4 || ^4.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Matthias\\SymfonyConfigTest\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthias Noback",
+                    "email": "matthiasnoback@gmail.com",
+                    "homepage": "http://php-and-symfony.matthiasnoback.nl"
+                }
+            ],
+            "description": "Library for testing user classes related to the Symfony Config Component",
+            "homepage": "https://github.com/matthiasnoback/SymfonyConfigTest",
+            "keywords": [
+                "config",
+                "phpunit",
+                "symfony"
+            ],
+            "time": "2018-03-05T09:21:43+00:00"
+        },
+        {
+            "name": "matthiasnoback/symfony-dependency-injection-test",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SymfonyTest/SymfonyDependencyInjectionTest.git",
+                "reference": "17e93d791c39849edce452723928b8172691e9c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SymfonyTest/SymfonyDependencyInjectionTest/zipball/17e93d791c39849edce452723928b8172691e9c9",
+                "reference": "17e93d791c39849edce452723928b8172691e9c9",
+                "shasum": ""
+            },
+            "require": {
+                "matthiasnoback/symfony-config-test": "^4.0",
+                "php": "^7.1",
+                "symfony/config": "^2.7 || ^3.3 || ^4.0",
+                "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",
+                "symfony/yaml": "^2.7 || ^3.3 || ^4.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matthias\\SymfonyDependencyInjectionTest\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthias Noback",
+                    "email": "matthiasnoback@gmail.com",
+                    "homepage": "http://php-and-symfony.matthiasnoback.nl"
+                }
+            ],
+            "description": "Library for testing user classes related to the Symfony Dependency Injection Component",
+            "homepage": "http://github.com/matthiasnoback/SymfonyDependencyInjectionTest",
+            "keywords": [
+                "Symfony2",
+                "dependency injection",
+                "phpunit"
+            ],
+            "time": "2018-03-06T08:36:41+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3803,7 +3911,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.1",
+        "ext-json": "*"
     },
     "platform-dev": []
 }

--- a/src/EventListener/JsonRequestBodyValidationSubscriber.php
+++ b/src/EventListener/JsonRequestBodyValidationSubscriber.php
@@ -11,7 +11,6 @@
 
 namespace Nijens\OpenapiBundle\EventListener;
 
-use Exception;
 use JsonSchema\Validator;
 use Nijens\OpenapiBundle\Exception\BadJsonRequestHttpException;
 use Nijens\OpenapiBundle\Exception\InvalidRequestHttpException;
@@ -162,15 +161,8 @@ class JsonRequestBodyValidationSubscriber implements EventSubscriberInterface
      */
     private function throwInvalidRequestException(array $errors): void
     {
-        $errorMessages = array_map(
-            function ($error) {
-                return $error['message'];
-            },
-            $errors
-        );
-
         $exception = new InvalidRequestHttpException('Validation of JSON request body failed.');
-        $exception->setErrors($errorMessages);
+        $exception->setErrors($errors);
 
         throw $exception;
     }

--- a/src/Exception/BadJsonRequestHttpException.php
+++ b/src/Exception/BadJsonRequestHttpException.php
@@ -30,7 +30,7 @@ class BadJsonRequestHttpException extends BadRequestHttpException implements Htt
 
         $previousException = $this->getPrevious();
         if ($previousException instanceof Exception) {
-            $errors[] = $previousException->getMessage();
+            $errors[] = array('message' => $previousException->getMessage());
         }
 
         return $errors;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,6 +13,7 @@
         <parameter key="nijens_openapi.json.validator.class">JsonSchema\Validator</parameter>
         <parameter key="nijens_openapi.event_subscriber.json_request_body_validation.class">Nijens\OpenapiBundle\EventListener\JsonRequestBodyValidationSubscriber</parameter>
         <parameter key="nijens_openapi.event_subscriber.json_response_exception.class">Nijens\OpenapiBundle\EventListener\JsonResponseExceptionSubscriber</parameter>
+        <parameter key="nijens_openapi.service.exception_json_response_builder.class">Nijens\OpenapiBundle\Service\ExceptionJsonResponseBuilder</parameter>
     </parameters>
 
     <services>
@@ -53,9 +54,13 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="nijens_openapi.service.exception_json_response_builder" class="%nijens_openapi.service.exception_json_response_builder.class%">
+            <argument>%kernel.debug%</argument>
+        </service>
+
         <service id="nijens_openapi.event_subscriber.json_response_exception" class="%nijens_openapi.event_subscriber.json_response_exception.class%">
             <argument type="service" id="router"/>
-            <argument>%kernel.debug%</argument>
+            <argument type="service" id="nijens_openapi.service.exception_json_response_builder"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Service/ExceptionJsonResponseBuilder.php
+++ b/src/Service/ExceptionJsonResponseBuilder.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Service;
+
+use Exception;
+use Nijens\OpenapiBundle\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Builds a JSON response to an exception for OpenAPI routes.
+ *
+ * @author David Cochrum <dcochrum@sonnysdirect.com>
+ */
+class ExceptionJsonResponseBuilder implements ExceptionJsonResponseBuilderInterface
+{
+    /**
+     * The boolean indicating if the kernel is in debug mode.
+     *
+     * @var bool
+     */
+    private $debugMode;
+
+    /**
+     * Default constructor.
+     *
+     * @param bool $debugMode
+     */
+    public function __construct(bool $debugMode)
+    {
+        $this->debugMode = $debugMode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(Exception $exception): JsonResponse
+    {
+        $response = new JsonResponse();
+
+        $statusCode = JsonResponse::HTTP_INTERNAL_SERVER_ERROR;
+        $message = 'Unexpected error.';
+
+        if ($exception instanceof HttpException) {
+            $statusCode = $exception->getStatusCode();
+        }
+
+        if ($this->debugMode || $exception instanceof HttpException) {
+            $message = $exception->getMessage();
+        }
+
+        $responseBody = array('message' => $message);
+        if ($exception instanceof HttpExceptionInterface) {
+            $responseBody['errors'] = array_map(function ($error) {
+                return $error['message'];
+            }, $exception->getErrors());
+        }
+
+        $response->setStatusCode($statusCode);
+        $response->setData($responseBody);
+
+        return $response;
+    }
+}

--- a/src/Service/ExceptionJsonResponseBuilderInterface.php
+++ b/src/Service/ExceptionJsonResponseBuilderInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Service;
+
+use Exception;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * Formats a response to an exception for OpenAPI routes.
+ *
+ * @author David Cochrum <dcochrum@sonnysdirect.com>
+ */
+interface ExceptionJsonResponseBuilderInterface
+{
+    /**
+     * Builds and provides a Response from the given Exception.
+     *
+     * @param Exception $exception
+     *
+     * @return JsonResponse
+     */
+    public function build(Exception $exception): JsonResponse;
+}

--- a/tests/DependencyInjection/NijensOpenapiExtensionTest.php
+++ b/tests/DependencyInjection/NijensOpenapiExtensionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\DependencyInjection;
+
+use JsonSchema\Validator;
+use League\JsonReference\Dereferencer;
+use League\JsonReference\ReferenceSerializer\InlineReferenceSerializer;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Nijens\OpenapiBundle\Controller\CatchAllController;
+use Nijens\OpenapiBundle\DependencyInjection\NijensOpenapiExtension;
+use Nijens\OpenapiBundle\EventListener\JsonRequestBodyValidationSubscriber;
+use Nijens\OpenapiBundle\EventListener\JsonResponseExceptionSubscriber;
+use Nijens\OpenapiBundle\Json\SchemaLoader;
+use Nijens\OpenapiBundle\Routing\RouteLoader;
+use Nijens\OpenapiBundle\Service\ExceptionJsonResponseBuilder;
+use Seld\JsonLint\JsonParser;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * NijensOpenapiExtensionTest.
+ *
+ * @author David Cochrum <dcochrum@sonnysdirect.com>
+ */
+class NijensOpenapiExtensionTest extends AbstractExtensionTestCase
+{
+    protected function getContainerExtensions()
+    {
+        return array(
+            new NijensOpenapiExtension(),
+        );
+    }
+
+    public function testXmlParsedCorrectly()
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('nijens_openapi.controller.catch_all.class', CatchAllController::class);
+        $this->assertContainerBuilderHasParameter('nijens_openapi.routing.loader.class', RouteLoader::class);
+        $this->assertContainerBuilderHasParameter('nijens_openapi.json.parser.class', JsonParser::class);
+        $this->assertContainerBuilderHasParameter('nijens_openapi.json.dereferencer.class', Dereferencer::class);
+        $this->assertContainerBuilderHasParameter('nijens_openapi.json.dereferencer.serializer.class', InlineReferenceSerializer::class);
+        $this->assertContainerBuilderHasParameter('nijens_openapi.json.schema_loader.class', SchemaLoader::class);
+        $this->assertContainerBuilderHasParameter('nijens_openapi.json.validator.class', Validator::class);
+        $this->assertContainerBuilderHasParameter('nijens_openapi.event_subscriber.json_request_body_validation.class', JsonRequestBodyValidationSubscriber::class);
+        $this->assertContainerBuilderHasParameter('nijens_openapi.event_subscriber.json_response_exception.class', JsonResponseExceptionSubscriber::class);
+        $this->assertContainerBuilderHasParameter('nijens_openapi.service.exception_json_response_builder.class', ExceptionJsonResponseBuilder::class);
+
+        $this->assertContainerBuilderHasService('nijens_openapi.controller.catch_all', CatchAllController::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.controller.catch_all', 0, new Reference('router'));
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('nijens_openapi.controller.catch_all', 'controller.service_arguments');
+
+        $this->assertContainerBuilderHasService('nijens_openapi.routing.loader', RouteLoader::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.routing.loader', 0, new Reference('nijens_openapi.json.schema_loader'));
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('nijens_openapi.routing.loader', 'routing.loader');
+
+        $this->assertContainerBuilderHasService('nijens_openapi.json.parser', JsonParser::class);
+
+        $this->assertContainerBuilderHasService('nijens_openapi.json.dereferencer', Dereferencer::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.json.dereferencer', 0, null);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.json.dereferencer', 1, new Reference('nijens_openapi.json.dereferencer.serializer'));
+
+        $this->assertContainerBuilderHasService('nijens_openapi.json.dereferencer.serializer', InlineReferenceSerializer::class);
+
+        $this->assertContainerBuilderHasService('nijens_openapi.json.schema_loader', SchemaLoader::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.json.schema_loader', 0, new Reference('file_locator'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.json.schema_loader', 1, new Reference('nijens_openapi.json.dereferencer'));
+
+        $this->assertContainerBuilderHasService('nijens_openapi.json.validator', Validator::class);
+
+        $this->assertContainerBuilderHasService('nijens_openapi.event_subscriber.json_request_body_validation', JsonRequestBodyValidationSubscriber::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 0, new Reference('router'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 1, new Reference('nijens_openapi.json.parser'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 2, new Reference('nijens_openapi.json.schema_loader'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 3, new Reference('nijens_openapi.json.validator'));
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('nijens_openapi.event_subscriber.json_request_body_validation', 'kernel.event_subscriber');
+
+        $this->assertContainerBuilderHasService('nijens_openapi.service.exception_json_response_builder', ExceptionJsonResponseBuilder::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.service.exception_json_response_builder', 0, '%kernel.debug%');
+
+        $this->assertContainerBuilderHasService('nijens_openapi.event_subscriber.json_response_exception');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_response_exception', 0, new Reference('router'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_response_exception', 1, new Reference('nijens_openapi.service.exception_json_response_builder'));
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('nijens_openapi.event_subscriber.json_response_exception', 'kernel.event_subscriber');
+    }
+}

--- a/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
+++ b/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
@@ -41,17 +41,17 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
     private $subscriber;
 
     /**
-     * @var MockObject
+     * @var MockObject|RouterInterface
      */
     private $routerMock;
 
     /**
-     * @var MockObject
+     * @var MockObject|JsonParser
      */
     private $jsonParserMock;
 
     /**
-     * @var MockObject
+     * @var MockObject|SchemaLoaderInterface
      */
     private $schemaLoaderMock;
 
@@ -132,6 +132,7 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
         $this->schemaLoaderMock->expects($this->never())
             ->method('load');
 
+        /** @var MockObject|HttpKernelInterface $kernelMock */
         $kernelMock = $this->getMockBuilder(HttpKernelInterface::class)
             ->getMock();
 
@@ -168,6 +169,7 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
         $this->schemaLoaderMock->expects($this->never())
             ->method('load');
 
+        /** @var MockObject|HttpKernelInterface $kernelMock */
         $kernelMock = $this->getMockBuilder(HttpKernelInterface::class)
             ->getMock();
 
@@ -203,6 +205,7 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
         $this->schemaLoaderMock->expects($this->never())
             ->method('load');
 
+        /** @var MockObject|HttpKernelInterface $kernelMock */
         $kernelMock = $this->getMockBuilder(HttpKernelInterface::class)
             ->getMock();
 
@@ -245,6 +248,7 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
         $this->schemaLoaderMock->expects($this->never())
             ->method('load');
 
+        /** @var MockObject|HttpKernelInterface $kernelMock */
         $kernelMock = $this->getMockBuilder(HttpKernelInterface::class)
             ->getMock();
 
@@ -299,6 +303,7 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
             ->with(__DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json')
             ->willReturn($schemaLoaderDereferencer->dereference('file://'.__DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json'));
 
+        /** @var MockObject|HttpKernelInterface $kernelMock */
         $kernelMock = $this->getMockBuilder(HttpKernelInterface::class)
             ->getMock();
 
@@ -317,8 +322,20 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
             // Also assert contents of errors.
             $this->assertSame(
                 array(
-                    'The property name is required',
-                    'The property invalid is not defined and the definition does not allow additional properties',
+                    array(
+                        'property' => 'name',
+                        'pointer' => '/name',
+                        'message' => 'The property name is required',
+                        'constraint' => 'required',
+                        'context' => 1,
+                    ),
+                    array(
+                        'property' => '',
+                        'pointer' => '',
+                        'message' => 'The property invalid is not defined and the definition does not allow additional properties',
+                        'constraint' => 'additionalProp',
+                        'context' => 1,
+                    ),
                 ),
                 $exception->getErrors()
             );
@@ -354,6 +371,7 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
             ->with(__DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json')
             ->willReturn($schemaLoaderDereferencer->dereference('file://'.__DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json'));
 
+        /** @var MockObject|HttpKernelInterface $kernelMock */
         $kernelMock = $this->getMockBuilder(HttpKernelInterface::class)
             ->getMock();
 

--- a/tests/Service/ExceptionJsonResponseBuilderTest.php
+++ b/tests/Service/ExceptionJsonResponseBuilderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Service;
+
+use Exception;
+use Nijens\OpenapiBundle\Exception\BadJsonRequestHttpException;
+use Nijens\OpenapiBundle\Exception\InvalidRequestHttpException;
+use Nijens\OpenapiBundle\Service\ExceptionJsonResponseBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * ExceptionJsonResponseBuilderTest.
+ */
+class ExceptionJsonResponseBuilderTest extends TestCase
+{
+    /**
+     * @var ExceptionJsonResponseBuilder
+     */
+    private $builder;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->builder = new ExceptionJsonResponseBuilder(false);
+    }
+
+    /**
+     * Tests if constructing a new JsonExceptionResponseBuilder instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame(false, 'debugMode', $this->builder);
+    }
+
+    /**
+     * Tests if JsonExceptionResponseBuilder::build builds a response with 'Unexpected error' message for non-http
+     * exceptions and not the actual error message, as that might expose private information.
+     *
+     * @depends testConstruct
+     */
+    public function testBuildReturnsJsonResponseWithUnexpectedErrorMessage()
+    {
+        $response = $this->builder->build(new Exception('This message should not be visible.'));
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(JsonResponse::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+        $this->assertSame('{"message":"Unexpected error."}', $response->getContent());
+    }
+
+    /**
+     * Tests if JsonExceptionResponseBuilder::build builds a response with the message and status of the http exception.
+     *
+     * @depends testConstruct
+     */
+    public function testBuildReturnsJsonResponseWithExceptionMessage()
+    {
+        $response = $this->builder->build(
+            new BadJsonRequestHttpException(
+                'This message should be visible.',
+                new Exception('This previous exception message should be visible too.')
+            )
+        );
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(JsonResponse::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertSame(
+            '{"message":"This message should be visible.","errors":["This previous exception message should be visible too."]}',
+            $response->getContent()
+        );
+    }
+
+    /**
+     * Tests if JsonExceptionResponseBuilder::build builds a response with the message of any exception when debug mode
+     * is active.
+     *
+     * @depends testConstruct
+     */
+    public function testBuildReturnsJsonResponseWithExceptionMessageInDebugMode()
+    {
+        $builder = new ExceptionJsonResponseBuilder(true);
+        $response = $builder->build(new Exception('This message should be visible in debug mode.'));
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(JsonResponse::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+        $this->assertSame('{"message":"This message should be visible in debug mode."}', $response->getContent());
+    }
+
+    /**
+     * Tests if JsonExceptionResponseBuilder::build builds a response with simplified error messages within an
+     * OpenapiBundle HttpExceptionInterface exception.
+     *
+     * @depends testConstruct
+     */
+    public function testBuildReturnsJsonResponseContainingSimplifiedOpenapiErrorMessages()
+    {
+        $exception = new InvalidRequestHttpException('An overall error message.');
+        $exception->setErrors([
+            ['ignore' => 'me', 'message' => 'An additional error message.'],
+            ['ignore' => 'me too', 'message' => 'Another additional error message.'],
+        ]);
+
+        $response = $this->builder->build($exception);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame($exception->getStatusCode(), $response->getStatusCode());
+        $this->assertSame('{"message":"An overall error message.","errors":["An additional error message.","Another additional error message."]}', $response->getContent());
+    }
+}


### PR DESCRIPTION
## Custom Error Handling

The default error response template looks like:
```json
{
    "message": "Validation of JSON request body failed.",
    "errors": [
        "The property iAmRequired is required",
        "The property iAmExtra is not defined and the definition does not allow additional properties"
    ]
}
```

If your project requires a different formatting of the response or perhaps different response codes, the default response builder can be overridden. Following the ["How to Decorate Services" guide from Symfony](https://symfony.com/doc/current/service_container/service_decoration.html), you can define your own service which implements `JsonResponseBuilderExceptionInterface` and handles the error response building instead of `nijens_openapi.service.json_response_builder_exception`. When validation against the schema fails, an exception will be thrown which implements `HttpExceptionInterface`. The `getErrors()` method will provide a multi-dimensional array similar to this:
```php
array(
    array(
        'property' => 'iAmRequired',
        'pointer' => '/iAmRequired',
        'message' => 'The property iAmRequired is required',
        'constraint' => 'required',
        'context' => 1,
    ),
    array(
        'property' => '',
        'pointer' => '',
        'message' => 'The property iAmExtra is not defined and the definition does not allow additional properties',
        'constraint' => 'additionalProp',
        'context' => 1,
    ),
)
```