### PR TITLE
Add YAML spec handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This bundle provides a route loader and request validator that is able to load o
 
 api:
     prefix: /api
-    resource: ../openapi.json
+    resource: ../openapi.json # or ../openapi.yaml
     type: openapi
     name_prefix: "api_"
 ```

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "justinrainbow/json-schema": "^5.2",
         "league/json-reference": "^1.1",
         "seld/jsonlint": "^1.7",
-        "symfony/framework-bundle": "^3.4 || ^4.0"
+        "symfony/framework-bundle": "^3.4 || ^4.0",
+        "symfony/yaml": "^3.4 || ^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b9769cb904aa7963fb8e22ae9a0e5ed",
+    "content-hash": "8c346a2896a39999402e4259aa57c446",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -1304,6 +1304,65 @@
                 "url"
             ],
             "time": "2018-10-28T18:38:52+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "fe87e3b24d15ec8948f0280ee867a65ca44fdbaa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/fe87e3b24d15ec8948f0280ee867a65ca44fdbaa",
+                "reference": "fe87e3b24d15ec8948f0280ee867a65ca44fdbaa",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-11-11T19:51:29+00:00"
         }
     ],
     "packages-dev": [
@@ -3754,65 +3813,6 @@
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
             "time": "2018-10-02T12:40:59+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v4.1.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/367e689b2fdc19965be435337b50bc8adf2746c9",
-                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:36:10+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/tests/Resources/specifications/route-loader-minimal.txt
+++ b/tests/Resources/specifications/route-loader-minimal.txt
@@ -1,0 +1,47 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "OpenAPI bundle minimal test specification",
+        "version": "0.1.0"
+    },
+    "paths": {
+        "/pets": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Returns a list of pets.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Pet": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int32",
+                        "readOnly": true,
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Dog"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Resources/specifications/route-loader-minimal.yaml
+++ b/tests/Resources/specifications/route-loader-minimal.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+    title: OpenAPI bundle minimal test specification
+    version: 0.1.0
+paths:
+    "/pets":
+        get:
+            responses:
+                '200':
+                    description: Returns a list of pets.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    "$ref": "#/components/schemas/Pet"
+components:
+    schemas:
+        Pet:
+            type: object
+            properties:
+                id:
+                    type: integer
+                    format: int32
+                    readOnly: true
+                    example: 1
+                name:
+                    type: string
+                    example: Dog

--- a/tests/Resources/specifications/route-loader-minimal.yml
+++ b/tests/Resources/specifications/route-loader-minimal.yml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+    title: OpenAPI bundle minimal test specification
+    version: 0.1.0
+paths:
+    "/pets":
+        get:
+            responses:
+                '200':
+                    description: Returns a list of pets.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    "$ref": "#/components/schemas/Pet"
+components:
+    schemas:
+        Pet:
+            type: object
+            properties:
+                id:
+                    type: integer
+                    format: int32
+                    readOnly: true
+                    example: 1
+                name:
+                    type: string
+                    example: Dog


### PR DESCRIPTION
Allow for the spec file referenced in the route definition to be `.json`, `.yaml`, or `.yml`