### PR TITLE
RouteLoader resource change detection

### DIFF
--- a/src/Json/SchemaLoader.php
+++ b/src/Json/SchemaLoader.php
@@ -14,6 +14,8 @@ namespace Nijens\OpenapiBundle\Json;
 use League\JsonReference\DereferencerInterface;
 use stdClass;
 use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Config\Resource\ResourceInterface;
 
 /**
  * Loads a dereferenced JSON schema.
@@ -52,9 +54,7 @@ class SchemaLoader implements SchemaLoaderInterface
     }
 
     /**
-     * @param string $file
-     *
-     * @return stdClass
+     * {@inheritdoc}
      */
     public function load(string $file): stdClass
     {
@@ -68,5 +68,18 @@ class SchemaLoader implements SchemaLoaderInterface
         }
 
         return $this->schemas[$locatedFile];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFileResource(string $file): ?ResourceInterface
+    {
+        $locatedFile = $this->fileLocator->locate($file);
+        if (isset($this->schemas[$locatedFile])) {
+            return new FileResource($locatedFile);
+        }
+
+        return null;
     }
 }

--- a/src/Json/SchemaLoaderInterface.php
+++ b/src/Json/SchemaLoaderInterface.php
@@ -12,6 +12,7 @@
 namespace Nijens\OpenapiBundle\Json;
 
 use stdClass;
+use Symfony\Component\Config\Resource\ResourceInterface;
 
 /**
  * Interface for JSON schema loaders.
@@ -21,11 +22,20 @@ use stdClass;
 interface SchemaLoaderInterface
 {
     /**
-     * Loads a dereferenced JSON schema.
+     * Loads and dereferences a JSON schema.
      *
      * @param string $file
      *
      * @return stdClass
      */
     public function load(string $file): stdClass;
+
+    /**
+     * Returns a FileResource for a loaded JSON schema.
+     *
+     * @param string $file
+     *
+     * @return ResourceInterface|null
+     */
+    public function getFileResource(string $file): ?ResourceInterface;
 }

--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -65,6 +65,7 @@ class RouteLoader extends Loader
         $jsonPointer = new JsonPointer($schema);
 
         $routeCollection = new RouteCollection();
+        $routeCollection->addResource($this->schemaLoader->getFileResource($resource));
 
         $paths = get_object_vars($jsonPointer->get('/paths'));
         foreach ($paths as $path => $pathItem) {

--- a/tests/Json/SchemaLoaderTest.php
+++ b/tests/Json/SchemaLoaderTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Json;
+
+use League\JsonReference\DereferencerInterface;
+use Nijens\OpenapiBundle\Json\SchemaLoader;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Config\Resource\FileResource;
+
+/**
+ * SchemaLoaderTest.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class SchemaLoaderTest extends TestCase
+{
+    /**
+     * @var SchemaLoader
+     */
+    private $schemaLoader;
+
+    /**
+     * @var MockObject
+     */
+    private $fileLocatorMock;
+
+    /**
+     * @var MockObject
+     */
+    private $dereferencerMock;
+
+    /**
+     * Creates a new SchemaLoader instance for testing.
+     */
+    protected function setUp()
+    {
+        $this->fileLocatorMock = $this->getMockBuilder(FileLocatorInterface::class)
+            ->getMock();
+
+        $this->dereferencerMock = $this->getMockBuilder(DereferencerInterface::class)
+            ->getMock();
+
+        $this->schemaLoader = new SchemaLoader($this->fileLocatorMock, $this->dereferencerMock);
+    }
+
+    /**
+     * Tests if constructing a new SchemaLoader instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame($this->fileLocatorMock, 'fileLocator', $this->schemaLoader);
+        $this->assertAttributeSame($this->dereferencerMock, 'dereferencer', $this->schemaLoader);
+    }
+
+    /**
+     * Tests if SchemaLoader::load locates and dereferences an JSON schema file.
+     *
+     * @depends testConstruct
+     */
+    public function testLoad()
+    {
+        $dereferenceJson = new stdClass();
+        $dereferenceJson->openapi = '3.0.0';
+
+        $this->fileLocatorMock->expects($this->once())
+            ->method('locate')
+            ->with('openapi.json')
+            ->willReturn('config/openapi.json');
+
+        $this->dereferencerMock->expects($this->once())
+            ->method('dereference')
+            ->with('file://config/openapi.json')
+            ->willReturn($dereferenceJson);
+
+        $schema = $this->schemaLoader->load('openapi.json');
+
+        $this->assertEquals($dereferenceJson, $schema);
+    }
+
+    /**
+     * Tests if SchemaLoader::getFileResource returns a FileResource for a loaded JSON schema file.
+     *
+     * @depends testLoad
+     */
+    public function testGetFileResource()
+    {
+        $dereferenceJson = new stdClass();
+        $dereferenceJson->openapi = '3.0.0';
+
+        $this->fileLocatorMock->expects($this->exactly(2))
+            ->method('locate')
+            ->with('route-loader-minimal.json')
+            ->willReturn(__DIR__.'/../Resources/specifications/route-loader-minimal.json');
+
+        $this->dereferencerMock->expects($this->once())
+            ->method('dereference')
+            ->with('file://'.__DIR__.'/../Resources/specifications/route-loader-minimal.json')
+            ->willReturn($dereferenceJson);
+
+        $this->schemaLoader->load('route-loader-minimal.json');
+
+        $fileResource = $this->schemaLoader->getFileResource('route-loader-minimal.json');
+
+        $this->assertInstanceOf(FileResource::class, $fileResource);
+    }
+
+    /**
+     * Tests if SchemaLoader::getFileResource returns for a file not loaded by the SchemaLoader.
+     *
+     * @depends testLoad
+     */
+    public function testGetFileResourceReturnsNull()
+    {
+        $this->fileLocatorMock->expects($this->once())
+            ->method('locate')
+            ->with('route-loader-minimal.json')
+            ->willReturn(__DIR__.'/../Resources/specifications/route-loader-minimal.json');
+
+        $fileResource = $this->schemaLoader->getFileResource('route-loader-minimal.json');
+
+        $this->assertNull($fileResource);
+    }
+}


### PR DESCRIPTION
When an OpenAPI specification file loaded by the `RouteLoader` is changed the routes aren't reloaded into the container cache.

This happens only during development of your project, but could be a productivity killer when making changes to the specification and having to clear the cache manually on every change.

This PR adds the OpenAPI specification file as `FileResource` to the `RouteCollection`. This way, the router should be able to detect the freshness of the routing cache and reload it when the specification file is changed.