### PR TITLE
Remove routecollection

### DIFF
--- a/src/EventListener/JsonRequestBodyValidationSubscriber.php
+++ b/src/EventListener/JsonRequestBodyValidationSubscriber.php
@@ -82,14 +82,15 @@ class JsonRequestBodyValidationSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $requestContentType = $request->headers->get('Content-Type');
 
-        if ($event->getRequest()->attributes->has('_nijens_openapi') === false) {
+        $routeOptions = $event->getRequest()->attributes->get('_nijens_openapi');
+
+        // Not an openAPI route.
+        if (isset($routeOptions['openapi_resource']) === false) {
             return;
         }
 
-        $routeOptions = $event->getRequest()->attributes->get('_nijens_openapi');
-        if (isset($routeOptions['openapi_resource']) === false ||
-            isset($routeOptions['openapi_json_request_validation_pointer']) === false
-        ) {
+        // No need for validation.
+        if (isset($routeOptions['openapi_json_request_validation_pointer']) === false) {
             return;
         }
 

--- a/src/EventListener/JsonResponseExceptionSubscriber.php
+++ b/src/EventListener/JsonResponseExceptionSubscriber.php
@@ -15,8 +15,6 @@ use Nijens\OpenapiBundle\Service\ExceptionJsonResponseBuilderInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Routing\Route;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Transforms an exception to a JSON response for OpenAPI routes.

--- a/src/EventListener/JsonResponseExceptionSubscriber.php
+++ b/src/EventListener/JsonResponseExceptionSubscriber.php
@@ -24,11 +24,6 @@ use Symfony\Component\Routing\RouterInterface;
 class JsonResponseExceptionSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
      * @var ExceptionJsonResponseBuilderInterface
      */
     private $responseBuilder;
@@ -48,12 +43,10 @@ class JsonResponseExceptionSubscriber implements EventSubscriberInterface
     /**
      * Constructs a new JsonResponseExceptionSubscriber instance.
      *
-     * @param RouterInterface                       $router
      * @param ExceptionJsonResponseBuilderInterface $responseBuilder
      */
-    public function __construct(RouterInterface $router, ExceptionJsonResponseBuilderInterface $responseBuilder)
+    public function __construct(ExceptionJsonResponseBuilderInterface $responseBuilder)
     {
-        $this->router = $router;
         $this->responseBuilder = $responseBuilder;
     }
 
@@ -64,13 +57,9 @@ class JsonResponseExceptionSubscriber implements EventSubscriberInterface
      */
     public function onKernelExceptionTransformToJsonResponse(GetResponseForExceptionEvent $event): void
     {
-        $request = $event->getRequest();
+        $routeOptions = $event->getRequest()->attributes->get('_nijens_openapi');
 
-        $route = $this->router->getRouteCollection()->get(
-            $request->attributes->get('_route')
-        );
-
-        if ($route instanceof Route === false || $route->hasOption('openapi_resource') === false) {
+        if (isset($routeOptions['openapi_resource']) === false) {
             return;
         }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -46,7 +46,6 @@
         <service id="nijens_openapi.json.validator" class="%nijens_openapi.json.validator.class%"/>
 
         <service id="nijens_openapi.event_subscriber.json_request_body_validation" class="%nijens_openapi.event_subscriber.json_request_body_validation.class%">
-            <argument type="service" id="router"/>
             <argument type="service" id="nijens_openapi.json.parser"/>
             <argument type="service" id="nijens_openapi.json.schema_loader"/>
             <argument type="service" id="nijens_openapi.json.validator"/>
@@ -59,7 +58,6 @@
         </service>
 
         <service id="nijens_openapi.event_subscriber.json_response_exception" class="%nijens_openapi.event_subscriber.json_response_exception.class%">
-            <argument type="service" id="router"/>
             <argument type="service" id="nijens_openapi.service.exception_json_response_builder"/>
 
             <tag name="kernel.event_subscriber"/>

--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -122,7 +122,7 @@ class RouteLoader extends Loader
         stdClass $operation
     ): void {
         $defaults = array();
-        $options = array(
+        $openApiConfiguration = array(
             'openapi_resource' => $resource,
         );
 
@@ -131,7 +131,7 @@ class RouteLoader extends Loader
         }
 
         if (isset($operation->requestBody->content->{'application/json'})) {
-            $options['openapi_json_request_validation_pointer'] = sprintf(
+            $openApiConfiguration['openapi_json_request_validation_pointer'] = sprintf(
                 '/paths/%s/%s/requestBody/content/%s/schema',
                 $jsonPointer->escape($path),
                 $requestMethod,
@@ -139,7 +139,9 @@ class RouteLoader extends Loader
             );
         }
 
-        $route = new Route($path, $defaults, array(), $options);
+        $defaults['_nijens_openapi'] = $openApiConfiguration;
+
+        $route = new Route($path, $defaults, array());
         $route->setMethods($requestMethod);
 
         $collection->add(

--- a/tests/DependencyInjection/NijensOpenapiExtensionTest.php
+++ b/tests/DependencyInjection/NijensOpenapiExtensionTest.php
@@ -55,7 +55,6 @@ class NijensOpenapiExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('nijens_openapi.service.exception_json_response_builder.class', ExceptionJsonResponseBuilder::class);
 
         $this->assertContainerBuilderHasService('nijens_openapi.controller.catch_all', CatchAllController::class);
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.controller.catch_all', 0, new Reference('router'));
         $this->assertContainerBuilderHasServiceDefinitionWithTag('nijens_openapi.controller.catch_all', 'controller.service_arguments');
 
         $this->assertContainerBuilderHasService('nijens_openapi.routing.loader', RouteLoader::class);
@@ -77,18 +76,16 @@ class NijensOpenapiExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('nijens_openapi.json.validator', Validator::class);
 
         $this->assertContainerBuilderHasService('nijens_openapi.event_subscriber.json_request_body_validation', JsonRequestBodyValidationSubscriber::class);
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 0, new Reference('router'));
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 1, new Reference('nijens_openapi.json.parser'));
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 2, new Reference('nijens_openapi.json.schema_loader'));
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 3, new Reference('nijens_openapi.json.validator'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 0, new Reference('nijens_openapi.json.parser'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 1, new Reference('nijens_openapi.json.schema_loader'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_request_body_validation', 2, new Reference('nijens_openapi.json.validator'));
         $this->assertContainerBuilderHasServiceDefinitionWithTag('nijens_openapi.event_subscriber.json_request_body_validation', 'kernel.event_subscriber');
 
         $this->assertContainerBuilderHasService('nijens_openapi.service.exception_json_response_builder', ExceptionJsonResponseBuilder::class);
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.service.exception_json_response_builder', 0, '%kernel.debug%');
 
         $this->assertContainerBuilderHasService('nijens_openapi.event_subscriber.json_response_exception');
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_response_exception', 0, new Reference('router'));
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_response_exception', 1, new Reference('nijens_openapi.service.exception_json_response_builder'));
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('nijens_openapi.event_subscriber.json_response_exception', 0, new Reference('nijens_openapi.service.exception_json_response_builder'));
         $this->assertContainerBuilderHasServiceDefinitionWithTag('nijens_openapi.event_subscriber.json_response_exception', 'kernel.event_subscriber');
     }
 }

--- a/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
+++ b/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
@@ -149,7 +149,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request();
         $request->headers->set('Content-Type', 'application/json');
-        $request->attributes->set('_route', 'test_route');
 
         $event = new GetResponseEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
 

--- a/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
+++ b/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
@@ -157,6 +157,36 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
     }
 
     /**
+     * Tests if JsonRequestBodyValidationSubscriber::validateRequestBody skips validation when the Route
+     * does not contain the following OpenAPI options set by the RouteLoader:
+     * - The JSON pointer to a JSON Schema in the OpenAPI specification.
+     *
+     * @depends testConstruct
+     */
+    public function testValidateRequestBodySkipsValidationWhenRouteDoesNotContainValidationPointer()
+    {
+        $this->jsonParserMock->expects($this->never())
+            ->method('lint');
+
+        $this->schemaLoaderMock->expects($this->never())
+            ->method('load');
+
+        /** @var MockObject|HttpKernelInterface $kernelMock */
+        $kernelMock = $this->getMockBuilder(HttpKernelInterface::class)
+            ->getMock();
+
+        $request = new Request();
+        $request->headers->set('Content-Type', 'application/json');
+        $request->attributes->set('_nijens_openapi', [
+            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+        ]);
+
+        $event = new GetResponseEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $this->subscriber->validateRequestBody($event);
+    }
+
+    /**
      * Tests if JsonRequestBodyValidationSubscriber::validateRequestBody throws a InvalidRequestHttpException
      * when the content-type of the request is not 'application/json'.
      *

--- a/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
+++ b/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
@@ -26,9 +26,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Routing\Route;
-use Symfony\Component\Routing\RouteCollection;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * JsonRequestBodyValidationSubscriberTest.
@@ -39,11 +36,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
      * @var JsonRequestBodyValidationSubscriber
      */
     private $subscriber;
-
-    /**
-     * @var MockObject|RouterInterface
-     */
-    private $routerMock;
 
     /**
      * @var MockObject|JsonParser
@@ -65,9 +57,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
      */
     protected function setUp()
     {
-        $this->routerMock = $this->getMockBuilder(RouterInterface::class)
-            ->getMock();
-
         $this->jsonParserMock = $this->getMockBuilder(JsonParser::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -78,7 +67,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
         $this->jsonValidator = new Validator();
 
         $this->subscriber = new JsonRequestBodyValidationSubscriber(
-            $this->routerMock,
             $this->jsonParserMock,
             $this->schemaLoaderMock,
             $this->jsonValidator
@@ -107,7 +95,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
      */
     public function testConstruct()
     {
-        $this->assertAttributeSame($this->routerMock, 'router', $this->subscriber);
         $this->assertAttributeSame($this->jsonParserMock, 'jsonParser', $this->subscriber);
         $this->assertAttributeSame($this->schemaLoaderMock, 'schemaLoader', $this->subscriber);
         $this->assertAttributeSame($this->jsonValidator, 'jsonValidator', $this->subscriber);
@@ -122,10 +109,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
      */
     public function testValidateRequestBodySkipsValidationWhenRouteIsNotAvailable()
     {
-        $this->routerMock->expects($this->once())
-            ->method('getRouteCollection')
-            ->willReturn(new RouteCollection());
-
         $this->jsonParserMock->expects($this->never())
             ->method('lint');
 
@@ -154,15 +137,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
      */
     public function testValidateRequestBodySkipsValidationWhenRouteDoesNotContainOpenApiOptions()
     {
-        $route = new Route('/test-route');
-
-        $routeCollection = new RouteCollection();
-        $routeCollection->add('test_route', $route);
-
-        $this->routerMock->expects($this->once())
-            ->method('getRouteCollection')
-            ->willReturn($routeCollection);
-
         $this->jsonParserMock->expects($this->never())
             ->method('lint');
 
@@ -190,15 +164,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
      */
     public function testValidateRequestBodyThrowsInvalidRequestHttpExceptionWhenRequestContentTypeInvalid()
     {
-        $route = $this->createRouteForTesting();
-
-        $routeCollection = new RouteCollection();
-        $routeCollection->add('test_route', $route);
-
-        $this->routerMock->expects($this->once())
-            ->method('getRouteCollection')
-            ->willReturn($routeCollection);
-
         $this->jsonParserMock->expects($this->never())
             ->method('lint');
 
@@ -211,7 +176,10 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request();
         $request->headers->set('Content-Type', 'application/xml');
-        $request->attributes->set('_route', 'test_route');
+        $request->attributes->set('_nijens_openapi', [
+            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+            'openapi_json_request_validation_pointer' => '/paths/~1pets/put/requestBody/content/application~1json/schema',
+        ]);
 
         $event = new GetResponseEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
 
@@ -229,16 +197,7 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
      */
     public function testValidateRequestBodyThrowsInvalidRequestHttpExceptionWhenRequestBodyIsInvalidJson()
     {
-        $route = $this->createRouteForTesting();
-
-        $routeCollection = new RouteCollection();
-        $routeCollection->add('test_route', $route);
-
         $requestBody = '{"invalid": "json';
-
-        $this->routerMock->expects($this->once())
-            ->method('getRouteCollection')
-            ->willReturn($routeCollection);
 
         $this->jsonParserMock->expects($this->once())
             ->method('lint')
@@ -254,7 +213,10 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request(array(), array(), array(), array(), array(), array(), $requestBody);
         $request->headers->set('Content-Type', 'application/json');
-        $request->attributes->set('_route', 'test_route');
+        $request->attributes->set('_nijens_openapi', [
+            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+            'openapi_json_request_validation_pointer' => '/paths/~1pets/put/requestBody/content/application~1json/schema',
+        ]);
 
         $event = new GetResponseEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
 
@@ -282,15 +244,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
      */
     public function testValidateRequestBodyThrowsInvalidRequestHttpExceptionWhenRequestBodyDoesNotValidateWithJsonSchema()
     {
-        $route = $this->createRouteForTesting();
-
-        $routeCollection = new RouteCollection();
-        $routeCollection->add('test_route', $route);
-
-        $this->routerMock->expects($this->once())
-            ->method('getRouteCollection')
-            ->willReturn($routeCollection);
-
         $requestBody = '{"invalid": "json"}';
 
         $this->jsonParserMock->expects($this->never())
@@ -309,7 +262,10 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request(array(), array(), array(), array(), array(), array(), $requestBody);
         $request->headers->set('Content-Type', 'application/json');
-        $request->attributes->set('_route', 'test_route');
+        $request->attributes->set('_nijens_openapi', [
+            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+            'openapi_json_request_validation_pointer' => '/paths/~1pets/put/requestBody/content/application~1json/schema',
+        ]);
 
         $event = new GetResponseEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
 
@@ -350,15 +306,6 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
      */
     public function testValidateRequestBodySuccessful()
     {
-        $route = $this->createRouteForTesting();
-
-        $routeCollection = new RouteCollection();
-        $routeCollection->add('test_route', $route);
-
-        $this->routerMock->expects($this->once())
-            ->method('getRouteCollection')
-            ->willReturn($routeCollection);
-
         $requestBody = '{"name": "Dog"}';
 
         $this->jsonParserMock->expects($this->never())
@@ -377,24 +324,13 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request(array(), array(), array(), array(), array(), array(), $requestBody);
         $request->headers->set('Content-Type', 'application/json');
-        $request->attributes->set('_route', 'test_route');
+        $request->attributes->set('_nijens_openapi', [
+            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+            'openapi_json_request_validation_pointer' => '/paths/~1pets/put/requestBody/content/application~1json/schema',
+        ]);
 
         $event = new GetResponseEvent($kernelMock, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $this->subscriber->validateRequestBody($event);
-    }
-
-    /**
-     * Creates a new Route for testing.
-     *
-     * @return Route
-     */
-    private function createRouteForTesting()
-    {
-        $route = new Route('/pets');
-        $route->setOption('openapi_resource', __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json');
-        $route->setOption('openapi_json_request_validation_pointer', '/paths/~1pets/put/requestBody/content/application~1json/schema');
-
-        return $route;
     }
 }

--- a/tests/Routing/RouteLoaderTest.php
+++ b/tests/Routing/RouteLoaderTest.php
@@ -80,7 +80,7 @@ class RouteLoaderTest extends TestCase
 
         $this->assertSame('/pets', $route->getPath());
         $this->assertSame(array(Request::METHOD_GET), $route->getMethods());
-        $this->assertSame('route-loader-minimal.json', $route->getOption('openapi_resource'));
+        $this->assertSame('route-loader-minimal.json', $route->getDefaults()['_nijens_openapi']['openapi_resource']);
     }
 
     /**
@@ -95,7 +95,7 @@ class RouteLoaderTest extends TestCase
 
         $this->assertSame('/pets', $route->getPath());
         $this->assertSame(array(Request::METHOD_GET), $route->getMethods());
-        $this->assertSame('route-loader-minimal.yaml', $route->getOption('openapi_resource'));
+        $this->assertSame('route-loader-minimal.yaml', $route->getDefaults()['_nijens_openapi']['openapi_resource']);
     }
 
     /**
@@ -110,7 +110,7 @@ class RouteLoaderTest extends TestCase
 
         $this->assertSame('/pets', $route->getPath());
         $this->assertSame(array(Request::METHOD_GET), $route->getMethods());
-        $this->assertSame('route-loader-minimal.yml', $route->getOption('openapi_resource'));
+        $this->assertSame('route-loader-minimal.yml', $route->getDefaults()['_nijens_openapi']['openapi_resource']);
     }
 
     /**
@@ -136,7 +136,7 @@ class RouteLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $route);
         $this->assertSame(
             '/paths/~1pets/put/requestBody/content/application~1json/schema',
-            $route->getOption('openapi_json_request_validation_pointer')
+            $route->getDefaults()['_nijens_openapi']['openapi_json_request_validation_pointer']
         );
     }
 


### PR DESCRIPTION
`$router->getRouteCollection()` can become quite slow with more complicated routers. This moves the configuration needed to validate the request from the route's options to its defaults. This means that they are accessible in the request parameters.

Fixes #19 