### PR TITLE
Change priority of listening for kernel.exception events in JsonResponseExceptionSubscriber

### DIFF
--- a/src/EventListener/JsonResponseExceptionSubscriber.php
+++ b/src/EventListener/JsonResponseExceptionSubscriber.php
@@ -40,7 +40,7 @@ class JsonResponseExceptionSubscriber implements EventSubscriberInterface
     {
         return array(
             KernelEvents::EXCEPTION => array(
-                array('onKernelExceptionTransformToJsonResponse', 0),
+                array('onKernelExceptionTransformToJsonResponse', 10),
             ),
         );
     }

--- a/tests/EventListener/JsonResponseExceptionSubscriberTest.php
+++ b/tests/EventListener/JsonResponseExceptionSubscriberTest.php
@@ -68,7 +68,7 @@ class JsonResponseExceptionSubscriberTest extends TestCase
         $this->assertSame(
             array(
                 KernelEvents::EXCEPTION => array(
-                    array('onKernelExceptionTransformToJsonResponse', 0),
+                    array('onKernelExceptionTransformToJsonResponse', 10),
                 ),
             ),
             $subscribedEvents


### PR DESCRIPTION
This PR changes the listening priority of `JsonResponseExceptionSubscriber` to be able to catch firewall exceptions.

The `ExceptionJsonResponseBuilder` does not yet provide a correct JSON response for the `AuthenticationException` and `AccessDeniedException`. This will be improved in a following PR.