### PR TITLE
Add support for nullable validation

### DIFF
--- a/src/Json/Schema/Constraint/TypeConstraint.php
+++ b/src/Json/Schema/Constraint/TypeConstraint.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Json\Schema\Constraint;
+
+use JsonSchema\Constraints\TypeConstraint as BaseTypeConstraint;
+use JsonSchema\Entity\JsonPointer;
+
+/**
+ * Extends the type check with the nullable property from the OpenAPI specification.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class TypeConstraint extends BaseTypeConstraint
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function check(&$value = null, $schema = null, JsonPointer $path = null, $i = null): void
+    {
+        $type = $schema->type ?? null;
+        $nullable = $schema->nullable ?? false;
+
+        if (is_array($type) === false) {
+            $type = [$type];
+        }
+
+        if ($nullable === true) {
+            $type[] = 'null';
+
+            $schema->type = $type;
+        }
+
+        parent::check($value, $schema, $path, $i);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,6 +11,7 @@
         <parameter key="nijens_openapi.json.dereferencer.serializer.class">League\JsonReference\ReferenceSerializer\InlineReferenceSerializer</parameter>
         <parameter key="nijens_openapi.json.schema_loader.class">Nijens\OpenapiBundle\Json\SchemaLoader</parameter>
         <parameter key="nijens_openapi.json.validator.class">JsonSchema\Validator</parameter>
+        <parameter key="nijens_openapi.json.validator.factory.class">JsonSchema\Constraints\Factory</parameter>
         <parameter key="nijens_openapi.event_subscriber.json_request_body_validation.class">Nijens\OpenapiBundle\EventListener\JsonRequestBodyValidationSubscriber</parameter>
         <parameter key="nijens_openapi.event_subscriber.json_response_exception.class">Nijens\OpenapiBundle\EventListener\JsonResponseExceptionSubscriber</parameter>
         <parameter key="nijens_openapi.service.exception_json_response_builder.class">Nijens\OpenapiBundle\Service\ExceptionJsonResponseBuilder</parameter>
@@ -43,7 +44,16 @@
             <argument type="service" id="nijens_openapi.json.dereferencer"/>
         </service>
 
-        <service id="nijens_openapi.json.validator" class="%nijens_openapi.json.validator.class%"/>
+        <service id="nijens_openapi.json.validator" class="%nijens_openapi.json.validator.class%">
+            <argument type="service" id="nijens_openapi.json.validator.factory" />
+        </service>
+
+        <service id="nijens_openapi.json.validator.factory" class="%nijens_openapi.json.validator.factory.class%">
+            <call method="setConstraintClass">
+                <argument>type</argument>
+                <argument>Nijens\OpenapiBundle\Json\Schema\Constraint\TypeConstraint</argument>
+            </call>
+        </service>
 
         <service id="nijens_openapi.event_subscriber.json_request_body_validation" class="%nijens_openapi.event_subscriber.json_request_body_validation.class%">
             <argument type="service" id="nijens_openapi.json.parser"/>

--- a/tests/Json/Schema/Constraint/TypeConstraintTest.php
+++ b/tests/Json/Schema/Constraint/TypeConstraintTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Json\Schema\Constraint;
+
+use Nijens\OpenapiBundle\Json\Schema\Constraint\TypeConstraint;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * Tests for {@see TypeConstraint}.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class TypeConstraintTest extends TestCase
+{
+    /**
+     * @var TypeConstraint
+     */
+    private $constraint;
+
+    /**
+     * Creates a {@see TypeConstraint} for testing.
+     */
+    protected function setUp(): void
+    {
+        $this->constraint = new TypeConstraint();
+    }
+
+    /**
+     * Tests if {@see TypeConstraint::check} returns the expected value with {@see TypeConstraint::isValid}.
+     *
+     * @dataProvider provideCheckTestCases
+     *
+     * @param mixed $value
+     */
+    public function testCheckNullable(string $type, bool $nullable, $value, bool $expectedIsValid): void
+    {
+        $schema = new stdClass();
+        $schema->type = $type;
+        $schema->nullable = $nullable;
+
+        $this->constraint->check($value, $schema);
+
+        $this->assertSame($expectedIsValid, $this->constraint->isValid());
+    }
+
+    /**
+     * Returns a list with test cases for {@see testCheckNullable}.
+     */
+    public function provideCheckTestCases(): array
+    {
+        return [
+            ['string', false, 'value', true],
+            ['string', true, 'value', true],
+            ['string', false, null, false],
+            ['string', true, null, true],
+        ];
+    }
+}


### PR DESCRIPTION
This PR add support for successful validation of `null` when the `nullable` property is set to `true`.

With this change the following schema, within an OpenAPI specification, will successfully validate both `string` and `null` values:
```json
{
    "type": "string",
    "nullable": true
}
```