### PR TITLE
Reverted priority change of listening to kernel.exception events in JsonResponseExceptionSubscriber

### DIFF
--- a/src/EventListener/JsonResponseExceptionSubscriber.php
+++ b/src/EventListener/JsonResponseExceptionSubscriber.php
@@ -33,7 +33,7 @@ class JsonResponseExceptionSubscriber implements EventSubscriberInterface
     {
         return [
             KernelEvents::EXCEPTION => [
-                ['onKernelExceptionTransformToJsonResponse', 10],
+                ['onKernelExceptionTransformToJsonResponse', 0],
             ],
         ];
     }

--- a/tests/EventListener/JsonResponseExceptionSubscriberTest.php
+++ b/tests/EventListener/JsonResponseExceptionSubscriberTest.php
@@ -63,7 +63,7 @@ class JsonResponseExceptionSubscriberTest extends TestCase
         $this->assertSame(
             [
                 KernelEvents::EXCEPTION => [
-                    ['onKernelExceptionTransformToJsonResponse', 10],
+                    ['onKernelExceptionTransformToJsonResponse', 0],
                 ],
             ],
             $subscribedEvents


### PR DESCRIPTION
This PR reverts the changes made in the priority of JsonResponseExceptionSubscriber to its former value because no correct JSON response exists for the AuthenticationException and AccessDeniedException.