### PR TITLE
Change RouteLoader to a FileLoader

### DIFF
--- a/src/Json/SchemaLoader.php
+++ b/src/Json/SchemaLoader.php
@@ -13,7 +13,6 @@ namespace Nijens\OpenapiBundle\Json;
 
 use Nijens\OpenapiBundle\Json\Loader\LoaderInterface;
 use stdClass;
-use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
 
@@ -24,11 +23,6 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  */
 class SchemaLoader implements SchemaLoaderInterface
 {
-    /**
-     * @var FileLocatorInterface
-     */
-    private $fileLocator;
-
     /**
      * @var LoaderInterface
      */
@@ -49,12 +43,8 @@ class SchemaLoader implements SchemaLoaderInterface
     /**
      * Constructs a new {@see SchemaLoader} instance.
      */
-    public function __construct(
-        FileLocatorInterface $fileLocator,
-        LoaderInterface $loader,
-        DereferencerInterface $dereferencer
-    ) {
-        $this->fileLocator = $fileLocator;
+    public function __construct(LoaderInterface $loader, DereferencerInterface $dereferencer)
+    {
         $this->loader = $loader;
         $this->dereferencer = $dereferencer;
     }
@@ -64,16 +54,14 @@ class SchemaLoader implements SchemaLoaderInterface
      */
     public function load(string $file): stdClass
     {
-        $locatedFile = $this->fileLocator->locate($file);
-
-        if (isset($this->schemas[$locatedFile]) === false) {
-            $schema = $this->loader->load($locatedFile);
+        if (isset($this->schemas[$file]) === false) {
+            $schema = $this->loader->load($file);
             $dereferencedSchema = $this->dereferencer->dereference($schema);
 
-            $this->schemas[$locatedFile] = $dereferencedSchema;
+            $this->schemas[$file] = $dereferencedSchema;
         }
 
-        return $this->schemas[$locatedFile];
+        return $this->schemas[$file];
     }
 
     /**
@@ -81,9 +69,8 @@ class SchemaLoader implements SchemaLoaderInterface
      */
     public function getFileResource(string $file): ?ResourceInterface
     {
-        $locatedFile = $this->fileLocator->locate($file);
-        if (isset($this->schemas[$locatedFile])) {
-            return new FileResource($locatedFile);
+        if (isset($this->schemas[$file])) {
+            return new FileResource($file);
         }
 
         return null;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -57,7 +57,6 @@
         </service>
 
         <service id="nijens_openapi.json.schema_loader" class="%nijens_openapi.json.schema_loader.class%">
-            <argument type="service" id="file_locator"/>
             <argument type="service" id="Nijens\OpenapiBundle\Json\Loader\LoaderInterface"/>
             <argument type="service" id="Nijens\OpenapiBundle\Json\DereferencerInterface"/>
         </service>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -23,6 +23,7 @@
         </service>
 
         <service id="nijens_openapi.routing.loader" class="%nijens_openapi.routing.loader.class%">
+            <argument type="service" id="file_locator"/>
             <argument type="service" id="nijens_openapi.json.schema_loader"/>
 
             <tag name="routing.loader"/>

--- a/tests/Json/SchemaLoaderTest.php
+++ b/tests/Json/SchemaLoaderTest.php
@@ -19,7 +19,6 @@ use Nijens\OpenapiBundle\Json\SchemaLoader;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Resource\FileResource;
 
 /**
@@ -33,11 +32,6 @@ class SchemaLoaderTest extends TestCase
      * @var SchemaLoader
      */
     private $schemaLoader;
-
-    /**
-     * @var MockObject|FileLocatorInterface
-     */
-    private $fileLocatorMock;
 
     /**
      * @var MockObject|LoaderInterface
@@ -54,12 +48,10 @@ class SchemaLoaderTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->fileLocatorMock = $this->createMock(FileLocatorInterface::class);
         $this->loaderMock = $this->createMock(LoaderInterface::class);
         $this->dereferencerMock = $this->createMock(DereferencerInterface::class);
 
         $this->schemaLoader = new SchemaLoader(
-            $this->fileLocatorMock,
             $this->loaderMock,
             $this->dereferencerMock
         );
@@ -73,11 +65,6 @@ class SchemaLoaderTest extends TestCase
         $dereferenceJson = new stdClass();
         $dereferenceJson->openapi = '3.0.0';
 
-        $this->fileLocatorMock->expects($this->once())
-            ->method('locate')
-            ->with('openapi.json')
-            ->willReturn('config/openapi.json');
-
         $this->loaderMock->expects($this->once())
             ->method('load')
             ->with('config/openapi.json')
@@ -88,7 +75,7 @@ class SchemaLoaderTest extends TestCase
             ->with($dereferenceJson)
             ->willReturn($dereferenceJson);
 
-        $schema = $this->schemaLoader->load('openapi.json');
+        $schema = $this->schemaLoader->load('config/openapi.json');
 
         $this->assertEquals($dereferenceJson, $schema);
     }
@@ -103,11 +90,6 @@ class SchemaLoaderTest extends TestCase
         $dereferenceJson = new stdClass();
         $dereferenceJson->openapi = '3.0.0';
 
-        $this->fileLocatorMock->expects($this->exactly(2))
-            ->method('locate')
-            ->with('route-loader-minimal.json')
-            ->willReturn(__DIR__.'/../Resources/specifications/route-loader-minimal.json');
-
         $this->loaderMock->expects($this->any())
             ->method('load')
             ->willReturn($dereferenceJson);
@@ -116,9 +98,9 @@ class SchemaLoaderTest extends TestCase
             ->method('dereference')
             ->willReturn($dereferenceJson);
 
-        $this->schemaLoader->load('route-loader-minimal.json');
+        $this->schemaLoader->load(__DIR__.'/../Resources/specifications/route-loader-minimal.json');
 
-        $fileResource = $this->schemaLoader->getFileResource('route-loader-minimal.json');
+        $fileResource = $this->schemaLoader->getFileResource(__DIR__.'/../Resources/specifications/route-loader-minimal.json');
 
         $this->assertInstanceOf(FileResource::class, $fileResource);
     }
@@ -130,11 +112,6 @@ class SchemaLoaderTest extends TestCase
      */
     public function testGetFileResourceReturnsNull()
     {
-        $this->fileLocatorMock->expects($this->once())
-            ->method('locate')
-            ->with('route-loader-minimal.json')
-            ->willReturn(__DIR__.'/../Resources/specifications/route-loader-minimal.json');
-
         $fileResource = $this->schemaLoader->getFileResource('route-loader-minimal.json');
 
         $this->assertNull($fileResource);

--- a/tests/Routing/RouteLoaderTest.php
+++ b/tests/Routing/RouteLoaderTest.php
@@ -42,14 +42,14 @@ class RouteLoaderTest extends TestCase
     protected function setUp(): void
     {
         $fileLocator = new FileLocator([
-            __DIR__.'/../Resources/specifications/',
+            __DIR__.'/../Resources/specifications',
         ]);
         $loader = new ChainLoader([new JsonLoader(), new YamlLoader()]);
         $dereferencer = new Dereferencer(new JsonPointer(), $loader);
 
         $schemaLoader = new SchemaLoader($fileLocator, $loader, $dereferencer);
 
-        $this->routeLoader = new RouteLoader($schemaLoader);
+        $this->routeLoader = new RouteLoader($fileLocator, $schemaLoader);
     }
 
     /**
@@ -72,7 +72,10 @@ class RouteLoaderTest extends TestCase
 
         $this->assertSame('/pets', $route->getPath());
         $this->assertSame([Request::METHOD_GET], $route->getMethods());
-        $this->assertSame('route-loader-minimal.json', $route->getDefaults()['_nijens_openapi']['openapi_resource']);
+        $this->assertSame(
+            __DIR__.'/../Resources/specifications/route-loader-minimal.json',
+            $route->getDefaults()['_nijens_openapi']['openapi_resource']
+        );
     }
 
     /**
@@ -87,7 +90,10 @@ class RouteLoaderTest extends TestCase
 
         $this->assertSame('/pets', $route->getPath());
         $this->assertSame([Request::METHOD_GET], $route->getMethods());
-        $this->assertSame('route-loader-minimal.yaml', $route->getDefaults()['_nijens_openapi']['openapi_resource']);
+        $this->assertSame(
+            __DIR__.'/../Resources/specifications/route-loader-minimal.yaml',
+            $route->getDefaults()['_nijens_openapi']['openapi_resource']
+        );
     }
 
     /**
@@ -102,7 +108,10 @@ class RouteLoaderTest extends TestCase
 
         $this->assertSame('/pets', $route->getPath());
         $this->assertSame([Request::METHOD_GET], $route->getMethods());
-        $this->assertSame('route-loader-minimal.yml', $route->getDefaults()['_nijens_openapi']['openapi_resource']);
+        $this->assertSame(
+            __DIR__.'/../Resources/specifications/route-loader-minimal.yml',
+            $route->getDefaults()['_nijens_openapi']['openapi_resource']
+        );
     }
 
     /**

--- a/tests/Routing/RouteLoaderTest.php
+++ b/tests/Routing/RouteLoaderTest.php
@@ -47,7 +47,7 @@ class RouteLoaderTest extends TestCase
         $loader = new ChainLoader([new JsonLoader(), new YamlLoader()]);
         $dereferencer = new Dereferencer(new JsonPointer(), $loader);
 
-        $schemaLoader = new SchemaLoader($fileLocator, $loader, $dereferencer);
+        $schemaLoader = new SchemaLoader($loader, $dereferencer);
 
         $this->routeLoader = new RouteLoader($fileLocator, $schemaLoader);
     }


### PR DESCRIPTION
This PR changes the `RouteLoader` extend from `Loader` to `FileLoader`.

By changing the `RouteLoader` to a `FileLoader` it implements the `FileLocator` and removes the need for the `FileLocator` inside the `SchemaLoader`.

Effectively solving the `Loading the file "openapi.yaml" from the global resource directory` deprecation warning for Symfony 5.x and still be compatible with Symfony 3.4.

Relates to: #23