### PR TITLE
Add testing of PHP 7.4 and 8.0 to the Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
         - vendor
         - $HOME/.composer
 
-matrix:
+jobs:
     include:
         - php: 7.3
           env: SYMFONY_VERSION=3.4.*
@@ -15,8 +15,17 @@ matrix:
           env: SYMFONY_VERSION=4.4.*
         - php: 7.3
           # env: SYMFONY_VERSION=5.1.*
-        - php: 7.3
+        - php: 7.4
+          # env: SYMFONY_VERSION=5.1.*
+        - php: master
+          # env: SYMFONY_VERSION=5.1.*
+        - php: 7.4
           env: PHP_CS_FIXER=true
+
+    allow_failures:
+        - php: master
+
+    fast_finish: true
 
 before_install: composer selfupdate
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ matrix:
         - php: 7.3
           env: SYMFONY_VERSION=4.4.*
         - php: 7.3
-          env: SYMFONY_VERSION=5.0.*
-        - php: 7.3
-          env: SYMFONY_VERSION=5.1.*
+          # env: SYMFONY_VERSION=5.1.*
         - php: 7.3
           env: PHP_CS_FIXER=true
 

--- a/src/EventListener/JsonRequestBodyValidationSubscriber.php
+++ b/src/EventListener/JsonRequestBodyValidationSubscriber.php
@@ -18,6 +18,8 @@ use Nijens\OpenapiBundle\Json\JsonPointer;
 use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
 use Seld\JsonLint\JsonParser;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**

--- a/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
+++ b/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
@@ -314,9 +314,10 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
     }
 
     /**
-     * Creates a request event.
+     * Creates a request event. The type of event is created based on which
+     * Symfony version is being tested.
      *
-     * @return RequestEvent|GetResponseEvent
+     * @return GetResponseEvent|RequestEvent
      */
     private function createRequestEvent(Request $request)
     {

--- a/tests/EventListener/JsonResponseExceptionSubscriberTest.php
+++ b/tests/EventListener/JsonResponseExceptionSubscriberTest.php
@@ -78,7 +78,7 @@ class JsonResponseExceptionSubscriberTest extends TestCase
         $request->attributes->set('_route', 'not_in_collection');
 
         $exceptionMock = $this->createMock(Exception::class);
-        $eventMock = $this->createResponseForExceptionEventWithException($request, $exceptionMock);
+        $eventMock = $this->createExceptionEvent($request, $exceptionMock);
 
         $this->subscriber->onKernelExceptionTransformToJsonResponse($eventMock);
 
@@ -95,7 +95,7 @@ class JsonResponseExceptionSubscriberTest extends TestCase
         $request->attributes->set('_route', 'no_openapi_route');
 
         $exceptionMock = $this->createMock(Exception::class);
-        $eventMock = $this->createResponseForExceptionEventWithException($request, $exceptionMock);
+        $eventMock = $this->createExceptionEvent($request, $exceptionMock);
 
         $this->subscriber->onKernelExceptionTransformToJsonResponse($eventMock);
 
@@ -115,7 +115,7 @@ class JsonResponseExceptionSubscriberTest extends TestCase
         ]);
 
         $exception = new Exception('This message should not be visible.');
-        $event = $this->createResponseForExceptionEventWithException($request, $exception);
+        $event = $this->createExceptionEvent($request, $exception);
 
         $response = $this->getMockBuilder(JsonResponse::class)
             ->disableOriginalConstructor()
@@ -130,11 +130,12 @@ class JsonResponseExceptionSubscriberTest extends TestCase
     }
 
     /**
-     * Create response for exception event with an exception.
+     * Creates an exception event. The type of event is created based on which
+     * Symfony version is being tested.
      *
      * @return GetResponseForExceptionEvent|ExceptionEvent
      */
-    private function createResponseForExceptionEventWithException(Request $request, Exception $exception)
+    private function createExceptionEvent(Request $request, Exception $exception)
     {
         $kernelMock = $this->createMock(HttpKernelInterface::class);
 


### PR DESCRIPTION
This PR adds testing of PHP 7.4 and 8.0 to the Travis CI build matrix.