### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/bin/parse-coverage
+++ b/.github/bin/parse-coverage
@@ -42,7 +42,7 @@ $coverageCovered = $coveragePercentage >= $minimumCoveragePercentage;
 fwrite(
     STDOUT,
     sprintf(
-        '::set-output name=coverage-percentage::%s%s',
+        '::set-output name=percentage::%s%s',
         $coveragePercentage,
         PHP_EOL
     )
@@ -51,8 +51,8 @@ fwrite(
 fwrite(
     STDOUT,
     sprintf(
-        '::set-output name=coverage-covered::%s%s',
-        $coverageCovered ? 'true' : 'false',
+        '::set-output name=conclusion::%s%s',
+        $coverageCovered ? 'success' : 'failure',
         PHP_EOL
     )
 );

--- a/.github/bin/parse-coverage
+++ b/.github/bin/parse-coverage
@@ -1,0 +1,60 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Script to parse PHPUnit XML coverage and return the coverage percentage and
+ * if the minimum coverage is covered is reached for GitHub Actions.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+
+$arguments = $_SERVER['argv'];
+array_shift($arguments);
+
+if (count($arguments) < 2) {
+    exit(1);
+}
+
+$coverageFile = $arguments[0] ?? null;
+if (isset($coverageFile) === false && is_readable($coverageFile) === false) {
+    fwrite(STDERR, 'Coverage file not readable.'.PHP_EOL);
+    exit(1);
+}
+
+$minimumCoveragePercentage = (float) $arguments[1];
+
+$dom = new DOMDocument();
+$dom->preserveWhiteSpace = false;
+$dom->load($coverageFile);
+
+$xpath = new DOMXPath($dom);
+$xpath->registerNamespace('x', 'https://schema.phpunit.de/coverage/1.0');
+
+$coveragePercentageAttribute = $xpath->query('/x:phpunit/x:project/x:directory[@name = "/"]/x:totals/x:lines/@percent')->item(0);
+if ($coveragePercentageAttribute === null) {
+    fwrite(STDERR, 'No coverage percentage found in file.'.PHP_EOL);
+    exit(1);
+}
+
+$coveragePercentage = (float) $coveragePercentageAttribute->nodeValue;
+$coverageCovered = $coveragePercentage >= $minimumCoveragePercentage;
+
+fwrite(
+    STDOUT,
+    sprintf(
+        '::set-output name=coverage-percentage::%s%s',
+        $coveragePercentage,
+        PHP_EOL
+    )
+);
+
+fwrite(
+    STDOUT,
+    sprintf(
+        '::set-output name=coverage-covered::%s%s',
+        $coverageCovered ? 'true' : 'false',
+        PHP_EOL
+    )
+);
+
+exit(0);

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -11,13 +11,13 @@ jobs:
             matrix:
                 php-version: ['7.3', '7.4']
                 symfony-version: ['3.4', '4.4']
-                phpunit-options: ['']
+                test-options: ['']
                 coverage: [false]
                 include:
                     - php-version: '7.4'
                       symfony-version: '5.1'
                       coverage: true
-                      phpunit-options: '--coverage-xml coverage-xml'
+                      test-options: '-with-coverage'
                       minimum-coverage-percentage: 95
 
         steps:
@@ -41,14 +41,11 @@ jobs:
                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                  restore-keys: ${{ runner.os }}-composer-
 
-            - name: Install dependencies
-              run: composer install --prefer-dist --no-progress --no-suggest
-
-            - name: Switch Symfony components to version ${{ matrix.symfony-version }}
-              run: composer remove friendsofphp/php-cs-fixer --dev && composer require "symfony/symfony:${{ matrix.symfony-version }}.*" --no-update && composer update symfony/* --prefer-dist --no-progress --no-suggest
+            - name: Install dependencies and switch Symfony components to version ${{ matrix.symfony-version }}
+              run: make switch-symfony version=${{ matrix.symfony-version }}
 
             - name: Run PHPUnit
-              run: ./vendor/bin/phpunit ${{ matrix.phpunit-options }}
+              run: make test${{ matrix.test-options }}
 
             - name: Parse PHPUnit coverage
               if: ${{ matrix.coverage == true }}
@@ -88,7 +85,7 @@ jobs:
                   coverage: none
 
             - name: Validate composer.json and composer.lock
-              run: composer validate --strict
+              run: make validate-dependencies
 
     code-style:
         name: Code standards
@@ -115,7 +112,7 @@ jobs:
                  restore-keys: ${{ runner.os }}-composer-
 
             - name: Install dependencies
-              run: composer install --prefer-dist --no-progress --no-suggest
+              run: make install
 
             - name: Check code standards
-              run: ./vendor/bin/php-cs-fixer fix --dry-run -v
+              run: make code-style-check

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -4,12 +4,13 @@ name: Continuous Integration
 
 jobs:
     test:
-        name: Tests (PHP ${{ matrix.php-version }})
+        name: Tests (Symfony ${{ matrix.symfony-version }} & PHP ${{ matrix.php-version }})
         runs-on: ubuntu-latest
 
         strategy:
             matrix:
                 php-version: ['7.3', '7.4']
+                symfony-version: ['3.4', '4.4', '5.1']
 
         steps:
             - uses: actions/checkout@v2
@@ -31,6 +32,9 @@ jobs:
                  path: ${{ steps.composer-cache.outputs.dir }}
                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                  restore-keys: ${{ runner.os }}-composer-
+
+            - name: Switch Symfony to version ${{ matrix.symfony-version }}
+              run: composer remove friendsofphp/php-cs-fixer --dev; composer require "symfony/symfony:${{ matrix.symfony-version }}" --no-update; composer update symfony/*
 
             - name: Install dependencies
               run: composer install --prefer-dist --no-progress --no-suggest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -69,11 +69,11 @@ jobs:
                       - antiope
                   name: Code coverage
                   head_sha: ${{ github.sha }}
-                  conclusion: success
+                  conclusion: ${{ steps.coverage.outputs.conclusion }}
                   status: completed
                   output: |
-                    title: Coverage at ${{ steps.coverage.outputs.coverage-percentage }}%
-                    summary: Coverage at ${{ steps.coverage.outputs.coverage-percentage }}%
+                    title: Coverage at ${{ steps.coverage.outputs.percentage }}%
+                    summary: Coverage at ${{ steps.coverage.outputs.percentage }}%
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -69,8 +69,8 @@ jobs:
                   conclusion: ${{ steps.coverage.outputs.conclusion }}
                   status: completed
                   output: |
-                    title: Coverage at ${{ steps.coverage.outputs.percentage }}%
-                    summary: Coverage at ${{ steps.coverage.outputs.percentage }}%
+                    title: Coverage at ${{ steps.coverage.outputs.percentage }}% (required minimum coverage is ${{ matrix.minimum-coverage-percentage }}%)
+                    summary: Coverage at ${{ steps.coverage.outputs.percentage }}% (required minimum coverage is ${{ matrix.minimum-coverage-percentage }}%)
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -33,11 +33,11 @@ jobs:
                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                  restore-keys: ${{ runner.os }}-composer-
 
-            - name: Switch Symfony to version ${{ matrix.symfony-version }}
-              run: composer remove friendsofphp/php-cs-fixer --dev; composer require "symfony/symfony:${{ matrix.symfony-version }}" --no-update; composer update symfony/*
-
             - name: Install dependencies
               run: composer install --prefer-dist --no-progress --no-suggest
+
+            - name: Switch Symfony components to version ${{ matrix.symfony-version }}
+              run: composer remove friendsofphp/php-cs-fixer --dev; composer require "symfony/symfony:${{ matrix.symfony-version }}" --no-update; composer update symfony/*
 
             - name: Run PHPUnit
               run: ./vendor/bin/phpunit

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -11,11 +11,13 @@ jobs:
             matrix:
                 php-version: ['7.3', '7.4']
                 symfony-version: ['3.4', '4.4', '5.1']
+                phpunit-options: ['']
                 coverage: [false]
                 include:
                     - php-version: '7.4'
                       symfony-version: '5.1'
                       coverage: true
+                      phpunit-options: '--coverage-xml coverage-xml'
                       minimum-coverage-percentage: 95
 
         steps:
@@ -45,13 +47,8 @@ jobs:
             - name: Switch Symfony components to version ${{ matrix.symfony-version }}
               run: composer remove friendsofphp/php-cs-fixer --dev && composer require "symfony/symfony:${{ matrix.symfony-version }}.*" --no-update && composer update symfony/* --prefer-dist --no-progress --no-suggest
 
-            - name: Run PHPUnit without coverage
-              if: ${{ matrix.coverage == false }}
-              run: ./vendor/bin/phpunit
-
-            - name: Run PHPUnit with coverage
-              if: ${{ matrix.coverage == true }}
-              run: ./vendor/bin/phpunit --coverage-xml coverage-xml
+            - name: Run PHPUnit
+              run: ./vendor/bin/phpunit ${{ matrix.phpunit-options }}
 
             - name: Parse PHPUnit coverage
               if: ${{ matrix.coverage == true }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -58,6 +58,25 @@ jobs:
               id: coverage
               run: ./.github/bin/parse-coverage coverage-xml/index.xml ${{ matrix.minimum-coverage-percentage }}
 
+            - name: Add coverage check run
+              uses: octokit/request-action@v2.x
+              if: ${{ matrix.coverage == true }}
+              with:
+                  route: POST /repos/:repository/check-runs
+                  repository: ${{ github.repository }}
+                  mediaType: |
+                    previews:
+                      - antiope
+                  name: Code coverage
+                  head_sha: ${{ github.sha }}
+                  conclusion: success
+                  status: completed
+                  output: |
+                    title: Coverage at ${{ steps.coverage.outputs.coverage-percentage }}%
+                    summary: Coverage at ${{ steps.coverage.outputs.coverage-percentage }}%
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     lockfile-integrity:
         name: Composer lockfile integrity
         runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -42,6 +42,22 @@ jobs:
             - name: Run PHPUnit
               run: ./vendor/bin/phpunit
 
+    lockfile-integrity:
+        name: Composer lockfile integrity
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
+                  coverage: none
+
+            - name: Validate composer.json and composer.lock
+              run: composer validate --strict
+
     code-style:
         name: Code standards
         runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -4,8 +4,12 @@ name: Continuous Integration
 
 jobs:
     test:
-        name: Tests
+        name: Tests (PHP ${{ matrix.php-version }})
         runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                php-version: ['7.2', '7.3', '7.4']
 
         steps:
             - uses: actions/checkout@v2
@@ -13,7 +17,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                 php-version: '7.4'
+                 php-version: ${{ matrix.php-version }}
                  extensions: mbstring, json, xml
                  coverage: pcov
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -22,3 +22,22 @@ jobs:
 
             - name: Run PHPUnit
               run: ./vendor/bin/phpunit
+
+    code-style:
+        name: Code standards
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
+                  coverage: none
+
+            - name: Install dependencies
+              run: composer install --prefer-dist
+
+            - name: Check code standards
+              run: ./vendor/bin/php-cs-fixer fix --dry-run -v

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             matrix:
                 php-version: ['7.3', '7.4']
-                symfony-version: ['3.4', '4.4', '5.1']
+                symfony-version: ['3.4', '4.4']
                 phpunit-options: ['']
                 coverage: [false]
                 include:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -9,7 +9,7 @@ jobs:
 
         strategy:
             matrix:
-                php-version: ['7.2', '7.3', '7.4']
+                php-version: ['7.3', '7.4']
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -11,6 +11,12 @@ jobs:
             matrix:
                 php-version: ['7.3', '7.4']
                 symfony-version: ['3.4', '4.4', '5.1']
+                coverage: [false]
+                include:
+                    - php-version: '7.4'
+                      symfony-version: '5.1'
+                      coverage: true
+                      minimum-coverage-percentage: 95
 
         steps:
             - uses: actions/checkout@v2
@@ -39,8 +45,18 @@ jobs:
             - name: Switch Symfony components to version ${{ matrix.symfony-version }}
               run: composer remove friendsofphp/php-cs-fixer --dev && composer require "symfony/symfony:${{ matrix.symfony-version }}.*" --no-update && composer update symfony/* --prefer-dist --no-progress --no-suggest
 
-            - name: Run PHPUnit
+            - name: Run PHPUnit without coverage
+              if: ${{ matrix.coverage == false }}
               run: ./vendor/bin/phpunit
+
+            - name: Run PHPUnit with coverage
+              if: ${{ matrix.coverage == true }}
+              run: ./vendor/bin/phpunit --coverage-xml coverage-xml
+
+            - name: Parse PHPUnit coverage
+              if: ${{ matrix.coverage == true }}
+              id: coverage
+              run: ./.github/bin/parse-coverage coverage-xml/index.xml ${{ matrix.minimum-coverage-percentage }}
 
     lockfile-integrity:
         name: Composer lockfile integrity

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -37,7 +37,7 @@ jobs:
               run: composer install --prefer-dist --no-progress --no-suggest
 
             - name: Switch Symfony components to version ${{ matrix.symfony-version }}
-              run: composer remove friendsofphp/php-cs-fixer --dev; composer require "symfony/symfony:${{ matrix.symfony-version }}" --no-update; composer update symfony/*
+              run: composer remove friendsofphp/php-cs-fixer --dev && composer require "symfony/symfony:${{ matrix.symfony-version }}.*" --no-update && composer update symfony/* --prefer-dist --no-progress --no-suggest
 
             - name: Run PHPUnit
               run: ./vendor/bin/phpunit

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -17,6 +17,17 @@ jobs:
                  extensions: mbstring, json, xml
                  coverage: pcov
 
+            - name: Detect dependency cache directory
+              id: composer-cache
+              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                 path: ${{ steps.composer-cache.outputs.dir }}
+                 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                 restore-keys: ${{ runner.os }}-composer-
+
             - name: Install dependencies
               run: composer install --prefer-dist --no-progress --no-suggest
 
@@ -35,6 +46,17 @@ jobs:
               with:
                   php-version: '7.4'
                   coverage: none
+
+            - name: Detect dependency cache directory
+              id: composer-cache
+              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                 path: ${{ steps.composer-cache.outputs.dir }}
+                 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                 restore-keys: ${{ runner.os }}-composer-
 
             - name: Install dependencies
               run: composer install --prefer-dist --no-progress --no-suggest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,24 @@
+on: [push, pull_request]
+
+name: Continuous Integration
+
+jobs:
+    test:
+        name: Tests
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                 php-version: '7.4'
+                 extensions: mbstring, json, xml
+                 coverage: pcov
+
+            - name: Install dependencies
+              run: composer install --prefer-dist
+
+            - name: Run PHPUnit
+              run: ./vendor/bin/phpunit

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,7 +18,7 @@ jobs:
                  coverage: pcov
 
             - name: Install dependencies
-              run: composer install --prefer-dist
+              run: composer install --prefer-dist --no-progress --no-suggest
 
             - name: Run PHPUnit
               run: ./vendor/bin/phpunit
@@ -37,7 +37,7 @@ jobs:
                   coverage: none
 
             - name: Install dependencies
-              run: composer install --prefer-dist
+              run: composer install --prefer-dist --no-progress --no-suggest
 
             - name: Check code standards
               run: ./vendor/bin/php-cs-fixer fix --dry-run -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,19 +27,25 @@ Please follow the following guidelines when creating a pull request:
 ## Coding standards and naming conventions
 This project follows the [Symfony code standards](https://symfony.com/doc/current/contributing/code/standards.html) with one exception:
 
-- No [Yoda conditions](https://en.wikipedia.org/wiki/Yoda_conditions). We're more a Han Solo fan, you see.
+- No [Yoda conditions](https://en.wikipedia.org/wiki/Yoda_conditions). We believe in creating unit tests instead.
 
 Code style standards are best fixed with the [PHP Coding Standards Fixer](https://cs.symfony.com/).
 Please check your code before creating a commit by running the following command:
 
 ``` bash
-vendor/bin/php-cs-fixer fix
+make code-style-fix
 ```
 
 
 ## Running Tests
-Run the entire testsuite with the following command to see if everything works like it should after your changes:
+Run the entire test suite with the following command to see if everything works like it should after your changes:
 
 ``` bash
-vendor/bin/phpunit
+make test
+```
+
+If you'd like to test your changes against an older Symfony version (eg. 4.4), you can do so by using the following command:
+
+```bash
+make switch-symfony version=4.4 test
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+SHELL := /bin/bash
+
+.DEFAULT_GOAL := help
+
+help: ## Display this help.
+	@printf "\nUsage:\n  make \033[36m<target>\033[0m"
+	@awk 'BEGIN {FS = ":.*##"; printf "\033[36m\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+.PHONY: help
+
+install: ## Install the dependencies with Composer.
+	composer install --prefer-dist --no-progress --no-suggest
+.PHONY: install
+
+switch-symfony: clean-dependencies install ## Switch the dependencies to another supported Symfony Framework version for testing.
+ifndef version
+	@printf "\nUsage:\n  make \033[36mswitch-symfony\033[0m version=\033[33m<version>\033[0m\n\n"
+	@exit 1
+endif
+
+	composer remove friendsofphp/php-cs-fixer --dev
+	composer require "symfony/symfony:$(version).*" --dev --no-update
+	composer update symfony/* --prefer-dist --no-progress --no-suggest
+.PHONY: switch-symfony-version
+
+test: install ## Run the unit tests.
+	./vendor/bin/phpunit
+.PHONY: tests
+
+test-with-coverage: install ## Run the unit tests with XML coverage report.
+	./vendor/bin/phpunit --coverage-xml coverage-xml
+.PHONY: tests-with-coverage
+
+code-style-fix: install ## Fix the code style.
+	./vendor/bin/php-cs-fixer fix --allow-risky=yes
+.PHONY: code-style
+
+code-style-check: install ## Check the code style.
+	./vendor/bin/php-cs-fixer fix --allow-risky=yes --dry-run -v
+.PHONY: code-style-check
+
+validate-dependencies: ## Validates the Composer configuration and lockfile.
+	composer validate --strict
+.PHONY: validate-dependencies
+
+clean-dependencies: ## Clears any changes made to the Composer configuration and removes installed dependencies.
+	@git checkout -- composer.*
+	@git clean -xf vendor
+.PHONY: clean


### PR DESCRIPTION
This PR adds the Continuous Integration as GitHub Actions workflow. This will eventually replace the current Travis CI builds.

Until the workflow is merged, the build output can be seen [here](https://github.com/niels-nijens/openapi-bundle/actions?query=workflow%3A%22Continuous+Integration%22+branch%3Agithub-actions).

### Todo
- [x] Minimal test job
- [x] Add code style checking
- [x] Add dependency caching
- [x] Add matrix for PHP versions
- [x] Add matrix for Symfony versions
- [ ] ~Implement Coveralls~
- [x] Replace Coveralls with a coverage solution within GitHub Actions
- [x] Add Makefile to be able to make the local testing easier
- [x] Add documentation on how to test this bundle (to CONTRIBUTING.md?)
