### PR TITLE
Fix missing files in version archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 # Exclude the following files from removal of releases with '-export-ignore'.
 /src                -export-ignore
+/src/**             -export-ignore
 /composer.json      -export-ignore
 /CONTRIBUTING.md    -export-ignore
 /LICENSE            -export-ignore


### PR DESCRIPTION
This PR fixes the missing files in the release archive of version [1.0.0](https://github.com/nijens/openapi-bundle/releases/tag/1.0.0).

Fixes #43.