### PR TITLE
Add serialization context builder based on the OpenAPI specification for the Symfony Serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/framework-bundle": "^4.4 || ^5.0",
         "symfony/http-foundation": "^4.4 || ^5.0",
         "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/property-access": "^4.4 || ^5.0",
         "symfony/routing": "^4.4 || ^5.0",
         "symfony/serializer": "^4.4 || ^5.0",
         "symfony/yaml": "^4.4 || ^5.0"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/http-foundation": "^4.4 || ^5.0",
         "symfony/http-kernel": "^4.4 || ^5.0",
         "symfony/routing": "^4.4 || ^5.0",
+        "symfony/serializer": "^4.4 || ^5.0",
         "symfony/yaml": "^4.4 || ^5.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d4b4297a00aa65dc9424e28d9bf1549",
+    "content-hash": "a3004e65c2c303c17eabe8b7b1350224",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -1847,6 +1847,171 @@
             "time": "2021-02-19T12:13:01+00:00"
         },
         {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:17:38+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
             "name": "symfony/polyfill-mbstring",
             "version": "v1.23.0",
             "source": {
@@ -2168,6 +2333,177 @@
             "time": "2021-05-21T13:25:03+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "8988399a556cffb0fba9bb3603f8d1ba4543eceb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/8988399a556cffb0fba9bb3603f8d1ba4543eceb",
+                "reference": "8988399a556cffb0fba9bb3603f8d1ba4543eceb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/property-info": "^5.2"
+            },
+            "require-dev": {
+                "symfony/cache": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "To cache access methods."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-26T17:43:10+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v5.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "6f8bff281f215dbf41929c7ec6f8309cdc0912cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/6f8bff281f215dbf41929c7ec6f8309cdc0912cf",
+                "reference": "6f8bff281f215dbf41929c7ec6f8309cdc0912cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/string": "^5.1"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/dependency-injection": "<4.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.10.4",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/cache": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/serializer": "^4.4|^5.0"
+            },
+            "suggest": {
+                "phpdocumentor/reflection-docblock": "To use the PHPDoc",
+                "psr/cache-implementation": "To cache results",
+                "symfony/doctrine-bridge": "To use Doctrine metadata",
+                "symfony/serializer": "To use Serializer metadata"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v5.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-31T12:40:48+00:00"
+        },
+        {
             "name": "symfony/routing",
             "version": "v5.3.0",
             "source": {
@@ -2437,6 +2773,89 @@
                 }
             ],
             "time": "2021-04-01T10:43:52+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
+                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-27T11:44:38+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -5887,171 +6306,6 @@
             "time": "2021-06-22T16:07:00+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.23.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-05-27T09:17:38+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.23.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-02-19T12:13:01+00:00"
-        },
-        {
             "name": "symfony/polyfill-php72",
             "version": "v1.23.0",
             "source": {
@@ -6250,89 +6504,6 @@
                 }
             ],
             "time": "2021-05-26T17:43:10+00:00"
-        },
-        {
-            "name": "symfony/string",
-            "version": "v5.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
-                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "~1.15"
-            },
-            "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/http-client": "^4.4|^5.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "grapheme",
-                "i18n",
-                "string",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/string/tree/v5.3.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-06-27T11:44:38+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d1c07abd4403455f6650f5d06cc6fee",
+    "content-hash": "5d4b4297a00aa65dc9424e28d9bf1549",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -2256,6 +2256,108 @@
                 }
             ],
             "time": "2021-05-26T17:43:10+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v5.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "96f6ff6582d1bf1bf08281b563a6c7c917efe6c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/96f6ff6582d1bf1bf08281b563a6c7c917efe6c1",
+                "reference": "96f6ff6582d1bf1bf08281b563a6c7c917efe6c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.12",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/property-access": "<4.4",
+                "symfony/property-info": "<5.3",
+                "symfony/yaml": "<4.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.12",
+                "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
+                "symfony/cache": "^4.4|^5.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/filesystem": "^4.4|^5.0",
+                "symfony/form": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/mime": "^4.4|^5.0",
+                "symfony/property-access": "^4.4.9|^5.0.9",
+                "symfony/property-info": "^5.3",
+                "symfony/uid": "^5.1",
+                "symfony/validator": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0",
+                "symfony/var-exporter": "^4.4|^5.0",
+                "symfony/yaml": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "For using the XML mapping loader.",
+                "symfony/mime": "For using a MIME type guesser within the DataUriNormalizer.",
+                "symfony/property-access": "For using the ObjectNormalizer.",
+                "symfony/property-info": "To deserialize relations.",
+                "symfony/var-exporter": "For using the metadata compiler.",
+                "symfony/yaml": "For using the default YAML mapping loader."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v5.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-10T18:05:39+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/src/EventListener/JsonRequestBodyValidationSubscriber.php
+++ b/src/EventListener/JsonRequestBodyValidationSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the OpenapiBundle package.
  *
@@ -16,6 +18,7 @@ use Nijens\OpenapiBundle\Exception\BadJsonRequestHttpException;
 use Nijens\OpenapiBundle\Exception\InvalidRequestHttpException;
 use Nijens\OpenapiBundle\Json\JsonPointer;
 use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
+use Nijens\OpenapiBundle\Routing\RouteContext;
 use Seld\JsonLint\JsonParser;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\HeaderUtils;
@@ -74,15 +77,15 @@ class JsonRequestBodyValidationSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $requestContentType = current(HeaderUtils::split($request->headers->get('Content-Type', ''), ';'));
 
-        $routeOptions = $event->getRequest()->attributes->get('_nijens_openapi');
+        $routeOptions = $event->getRequest()->attributes->get(RouteContext::REQUEST_ATTRIBUTE);
 
         // Not an openAPI route.
-        if (isset($routeOptions['openapi_resource']) === false) {
+        if (isset($routeOptions[RouteContext::RESOURCE]) === false) {
             return;
         }
 
         // No need for validation.
-        if (isset($routeOptions['openapi_json_request_validation_pointer']) === false) {
+        if (isset($routeOptions[RouteContext::JSON_REQUEST_VALIDATION_POINTER]) === false) {
             return;
         }
 
@@ -94,8 +97,8 @@ class JsonRequestBodyValidationSubscriber implements EventSubscriberInterface
         $decodedJsonRequestBody = $this->validateJsonRequestBody($requestBody);
 
         $this->validateJsonAgainstSchema(
-            $routeOptions['openapi_resource'],
-            $routeOptions['openapi_json_request_validation_pointer'],
+            $routeOptions[RouteContext::RESOURCE],
+            $routeOptions[RouteContext::JSON_REQUEST_VALIDATION_POINTER],
             $decodedJsonRequestBody
         );
     }

--- a/src/EventListener/JsonResponseExceptionSubscriber.php
+++ b/src/EventListener/JsonResponseExceptionSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the OpenapiBundle package.
  *
@@ -12,6 +14,7 @@
 namespace Nijens\OpenapiBundle\EventListener;
 
 use Exception;
+use Nijens\OpenapiBundle\Routing\RouteContext;
 use Nijens\OpenapiBundle\Service\ExceptionJsonResponseBuilderInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -52,9 +55,9 @@ class JsonResponseExceptionSubscriber implements EventSubscriberInterface
      */
     public function onKernelExceptionTransformToJsonResponse(ExceptionEvent $event): void
     {
-        $routeOptions = $event->getRequest()->attributes->get('_nijens_openapi');
+        $routeOptions = $event->getRequest()->attributes->get(RouteContext::REQUEST_ATTRIBUTE);
 
-        if (isset($routeOptions['openapi_resource']) === false) {
+        if (isset($routeOptions[RouteContext::RESOURCE]) === false) {
             return;
         }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -89,5 +89,11 @@
 
             <tag name="kernel.event_subscriber"/>
         </service>
+
+        <service id="Nijens\OpenapiBundle\Serialization\SerializationContextBuilder">
+            <argument type="service" id="nijens_openapi.json.schema_loader"/>
+        </service>
+
+        <service id="Nijens\OpenapiBundle\Serialization\SerializationContextBuilderInterface" alias="Nijens\OpenapiBundle\Serialization\SerializationContextBuilder"/>
     </services>
 </container>

--- a/src/Routing/RouteContext.php
+++ b/src/Routing/RouteContext.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Routing;
+
+/**
+ * Contains the context keys added by the {@see RouteLoader}.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+final class RouteContext
+{
+    public const REQUEST_ATTRIBUTE = '_nijens_openapi';
+
+    public const RESOURCE = 'openapi_resource';
+
+    public const JSON_REQUEST_VALIDATION_POINTER = 'openapi_json_request_validation_pointer';
+}

--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the OpenapiBundle package.
  *
@@ -113,7 +115,7 @@ class RouteLoader extends FileLoader
     ): void {
         $defaults = [];
         $openApiConfiguration = [
-            'openapi_resource' => $resource,
+            RouteContext::RESOURCE => $resource,
         ];
 
         if (isset($operation->{'x-symfony-controller'})) {
@@ -121,7 +123,7 @@ class RouteLoader extends FileLoader
         }
 
         if (isset($operation->requestBody->content->{'application/json'})) {
-            $openApiConfiguration['openapi_json_request_validation_pointer'] = sprintf(
+            $openApiConfiguration[RouteContext::JSON_REQUEST_VALIDATION_POINTER] = sprintf(
                 '/paths/%s/%s/requestBody/content/%s/schema',
                 $jsonPointer->escape($path),
                 $requestMethod,
@@ -129,7 +131,7 @@ class RouteLoader extends FileLoader
             );
         }
 
-        $defaults['_nijens_openapi'] = $openApiConfiguration;
+        $defaults[RouteContext::REQUEST_ATTRIBUTE] = $openApiConfiguration;
 
         $route = new Route($path, $defaults, []);
         $route->setMethods($requestMethod);
@@ -180,7 +182,7 @@ class RouteLoader extends FileLoader
             '/{catchall}',
             [
                 '_controller' => CatchAllController::CONTROLLER_REFERENCE,
-                '_nijens_openapi' => ['openapi_resource' => $resource],
+                RouteContext::REQUEST_ATTRIBUTE => [RouteContext::RESOURCE => $resource],
             ],
             ['catchall' => '.*']
         );

--- a/src/Serialization/SerializationContextBuilder.php
+++ b/src/Serialization/SerializationContextBuilder.php
@@ -65,6 +65,10 @@ class SerializationContextBuilder implements SerializationContextBuilderInterfac
             return $this->getAttributeContextFromCombinedSchemaObject($schemaObject);
         }
 
+        if (isset($schemaObject->type) === false) {
+            return [];
+        }
+
         switch ($schemaObject->type) {
             case 'object':
                 return $this->getAttributeContextFromSchemaObjectProperties($schemaObject);

--- a/src/Serialization/SerializationContextBuilder.php
+++ b/src/Serialization/SerializationContextBuilder.php
@@ -16,6 +16,7 @@ namespace Nijens\OpenapiBundle\Serialization;
 use Nijens\OpenapiBundle\Json\JsonPointer;
 use Nijens\OpenapiBundle\Json\Reference;
 use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
+use stdClass;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -50,6 +51,9 @@ class SerializationContextBuilder implements SerializationContextBuilderInterfac
         ];
     }
 
+    /**
+     * @param stdClass|Reference $schemaObject
+     */
     private function getAttributeContextFromSchemaObject($schemaObject): array
     {
         if ($schemaObject instanceof Reference) {
@@ -59,22 +63,27 @@ class SerializationContextBuilder implements SerializationContextBuilderInterfac
 
         switch ($schemaObject->type) {
             case 'object':
-                $objectContext = [];
-                foreach ($schemaObject->properties as $propertyKey => $property) {
-                    $propertyContext = $this->getAttributeContextFromSchemaObject($property);
-                    if (empty($propertyContext)) {
-                        $objectContext[] = $propertyKey;
-                        continue;
-                    }
-
-                    $objectContext[$propertyKey] = $propertyContext;
-                }
-
-                return $objectContext;
+                return $this->getAttributeContextFromSchemaObjectProperties($schemaObject);
             case 'array':
                 return $this->getAttributeContextFromSchemaObject($schemaObject->items);
         }
 
         return [];
+    }
+
+    private function getAttributeContextFromSchemaObjectProperties(stdClass $schemaObject): array
+    {
+        $objectContext = [];
+        foreach ($schemaObject->properties as $propertyKey => $property) {
+            $propertyContext = $this->getAttributeContextFromSchemaObject($property);
+            if (empty($propertyContext)) {
+                $objectContext[] = $propertyKey;
+                continue;
+            }
+
+            $objectContext[$propertyKey] = $propertyContext;
+        }
+
+        return $objectContext;
     }
 }

--- a/src/Serialization/SerializationContextBuilder.php
+++ b/src/Serialization/SerializationContextBuilder.php
@@ -61,6 +61,10 @@ class SerializationContextBuilder implements SerializationContextBuilderInterfac
             $schemaObject = $jsonPointer->get($schemaObject->getPointer());
         }
 
+        if (isset($schemaObject->allOf)) {
+            return $this->getAttributeContextFromCombinedSchemaObject($schemaObject);
+        }
+
         switch ($schemaObject->type) {
             case 'object':
                 return $this->getAttributeContextFromSchemaObjectProperties($schemaObject);
@@ -69,6 +73,16 @@ class SerializationContextBuilder implements SerializationContextBuilderInterfac
         }
 
         return [];
+    }
+
+    private function getAttributeContextFromCombinedSchemaObject(stdClass $schemaObject): array
+    {
+        $context = [];
+        foreach ($schemaObject->allOf as $allOfSchemaObject) {
+            $context = array_merge($context, $this->getAttributeContextFromSchemaObject($allOfSchemaObject));
+        }
+
+        return $context;
     }
 
     private function getAttributeContextFromSchemaObjectProperties(stdClass $schemaObject): array

--- a/src/Serialization/SerializationContextBuilder.php
+++ b/src/Serialization/SerializationContextBuilder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Serialization;
+
+use Nijens\OpenapiBundle\Json\JsonPointer;
+use Nijens\OpenapiBundle\Json\Reference;
+use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Creates a serialization context for {@see SerializerInterface::serialize} based on the provided schema object name.
+ *
+ * @experimental
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class SerializationContextBuilder implements SerializationContextBuilderInterface
+{
+    /**
+     * @var SchemaLoaderInterface
+     */
+    private $schemaLoader;
+
+    public function __construct(SchemaLoaderInterface $schemaLoader)
+    {
+        $this->schemaLoader = $schemaLoader;
+    }
+
+    public function getContextForSchemaObject(string $schemaObjectName, string $openApiSpecificationFile): array
+    {
+        $jsonPointer = new JsonPointer($this->schemaLoader->load($openApiSpecificationFile));
+        $schemaObject = $jsonPointer->get(sprintf('/components/schemas/%s', $schemaObjectName));
+
+        return [
+            AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+            AbstractNormalizer::ATTRIBUTES => $this->getAttributeContextFromSchemaObject($schemaObject),
+        ];
+    }
+
+    private function getAttributeContextFromSchemaObject($schemaObject): array
+    {
+        if ($schemaObject instanceof Reference) {
+            $jsonPointer = new JsonPointer($schemaObject->getJsonSchema());
+            $schemaObject = $jsonPointer->get($schemaObject->getPointer());
+        }
+
+        switch ($schemaObject->type) {
+            case 'object':
+                $objectContext = [];
+                foreach ($schemaObject->properties as $propertyKey => $property) {
+                    $propertyContext = $this->getAttributeContextFromSchemaObject($property);
+                    if (empty($propertyContext)) {
+                        $objectContext[] = $propertyKey;
+                        continue;
+                    }
+
+                    $objectContext[$propertyKey] = $propertyContext;
+                }
+
+                return $objectContext;
+            case 'array':
+                return $this->getAttributeContextFromSchemaObject($schemaObject->items);
+        }
+
+        return [];
+    }
+}

--- a/src/Serialization/SerializationContextBuilderInterface.php
+++ b/src/Serialization/SerializationContextBuilderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Serialization;
+
+/**
+ * Interface for creating a serialization context for {@see SerializerInterface::serialize}.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+interface SerializationContextBuilderInterface
+{
+    public function getContextForSchemaObject(string $schemaObjectName, string $openApiSpecificationFile): array;
+}

--- a/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
+++ b/tests/EventListener/JsonRequestBodyValidationSubscriberTest.php
@@ -18,6 +18,7 @@ use Nijens\OpenapiBundle\EventListener\JsonRequestBodyValidationSubscriber;
 use Nijens\OpenapiBundle\Exception\BadJsonRequestHttpException;
 use Nijens\OpenapiBundle\Exception\InvalidRequestHttpException;
 use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
+use Nijens\OpenapiBundle\Routing\RouteContext;
 use Nijens\OpenapiBundle\Routing\RouteLoader;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -151,9 +152,12 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request();
         $request->headers->set('Content-Type', 'application/json');
-        $request->attributes->set('_nijens_openapi', [
-            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
-        ]);
+        $request->attributes->set(
+            RouteContext::REQUEST_ATTRIBUTE,
+            [
+                RouteContext::RESOURCE => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+            ]
+        );
 
         $event = $this->createRequestEvent($request);
 
@@ -163,10 +167,13 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
     public function testCannotValidateRequestBodyWhenRequestContentTypeNotSet(): void
     {
         $request = new Request();
-        $request->attributes->set('_nijens_openapi', [
-            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
-            'openapi_json_request_validation_pointer' => '/paths/~1pets/put/requestBody/content/application~1json/schema',
-        ]);
+        $request->attributes->set(
+            RouteContext::REQUEST_ATTRIBUTE,
+            [
+                RouteContext::RESOURCE => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+                RouteContext::JSON_REQUEST_VALIDATION_POINTER => '/paths/~1pets/put/requestBody/content/application~1json/schema',
+            ]
+        );
 
         $event = $this->createRequestEvent($request);
 
@@ -190,10 +197,13 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request();
         $request->headers->set('Content-Type', 'application/xml');
-        $request->attributes->set('_nijens_openapi', [
-            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
-            'openapi_json_request_validation_pointer' => '/paths/~1pets/put/requestBody/content/application~1json/schema',
-        ]);
+        $request->attributes->set(
+            RouteContext::REQUEST_ATTRIBUTE,
+            [
+                RouteContext::RESOURCE => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+                RouteContext::JSON_REQUEST_VALIDATION_POINTER => '/paths/~1pets/put/requestBody/content/application~1json/schema',
+            ]
+        );
 
         $event = $this->createRequestEvent($request);
 
@@ -221,10 +231,13 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request([], [], [], [], [], [], $requestBody);
         $request->headers->set('Content-Type', 'application/json');
-        $request->attributes->set('_nijens_openapi', [
-            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
-            'openapi_json_request_validation_pointer' => '/paths/~1pets/put/requestBody/content/application~1json/schema',
-        ]);
+        $request->attributes->set(
+            RouteContext::REQUEST_ATTRIBUTE,
+            [
+                RouteContext::RESOURCE => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+                RouteContext::JSON_REQUEST_VALIDATION_POINTER => '/paths/~1pets/put/requestBody/content/application~1json/schema',
+            ]
+        );
 
         $event = $this->createRequestEvent($request);
 
@@ -262,10 +275,13 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request([], [], [], [], [], [], $requestBody);
         $request->headers->set('Content-Type', 'application/json');
-        $request->attributes->set('_nijens_openapi', [
-            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
-            'openapi_json_request_validation_pointer' => '/paths/~1pets/put/requestBody/content/application~1json/schema',
-        ]);
+        $request->attributes->set(
+            RouteContext::REQUEST_ATTRIBUTE,
+            [
+                RouteContext::RESOURCE => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+                RouteContext::JSON_REQUEST_VALIDATION_POINTER => '/paths/~1pets/put/requestBody/content/application~1json/schema',
+            ]
+        );
 
         $event = $this->createRequestEvent($request);
 
@@ -320,10 +336,13 @@ class JsonRequestBodyValidationSubscriberTest extends TestCase
 
         $request = new Request([], [], [], [], [], [], $requestBody);
         $request->headers->set('Content-Type', $requestContentType);
-        $request->attributes->set('_nijens_openapi', [
-            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
-            'openapi_json_request_validation_pointer' => '/paths/~1pets/put/requestBody/content/application~1json/schema',
-        ]);
+        $request->attributes->set(
+            RouteContext::REQUEST_ATTRIBUTE,
+            [
+                RouteContext::RESOURCE => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+                RouteContext::JSON_REQUEST_VALIDATION_POINTER => '/paths/~1pets/put/requestBody/content/application~1json/schema',
+            ]
+        );
 
         $event = $this->createRequestEvent($request);
 

--- a/tests/EventListener/JsonResponseExceptionSubscriberTest.php
+++ b/tests/EventListener/JsonResponseExceptionSubscriberTest.php
@@ -15,6 +15,7 @@ namespace Nijens\OpenapiBundle\Tests\EventListener;
 
 use Exception;
 use Nijens\OpenapiBundle\EventListener\JsonResponseExceptionSubscriber;
+use Nijens\OpenapiBundle\Routing\RouteContext;
 use Nijens\OpenapiBundle\Service\ExceptionJsonResponseBuilderInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Route;
 
 /**
  * Tests the {@see JsonResponseExceptionSubscriber}.
@@ -86,7 +88,7 @@ class JsonResponseExceptionSubscriberTest extends TestCase
 
     /**
      * Tests if {@see JsonResponseExceptionSubscriber::onKernelExceptionTransformToJsonResponse}
-     * sets no response on the event when the Route does not have the 'openapi_resource' option set.
+     * sets no response on the event when the Route does not have the {@see RouteContext::RESOURCE} option set.
      */
     public function testOnKernelExceptionTransformToJsonResponseDoesNothingWhenRouteIsNotAnOpenapiRoute(): void
     {
@@ -103,15 +105,18 @@ class JsonResponseExceptionSubscriberTest extends TestCase
 
     /**
      * Tests if {@see JsonResponseExceptionSubscriber::onKernelExceptionTransformToJsonResponse}
-     * sets a response when the Route does have the 'openapi_resource' option set.
+     * sets a response when the Route does have the {@see RouteContext::RESOURCE} option set.
      */
     public function testOnKernelExceptionTransformToJsonResponseSetsResponseWhenRouteIsAnOpenapiRoute(): void
     {
         $request = new Request();
         $request->attributes->set('_route', 'openapi_route');
-        $request->attributes->set('_nijens_openapi', [
-            'openapi_resource' => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
-        ]);
+        $request->attributes->set(
+            RouteContext::REQUEST_ATTRIBUTE,
+            [
+                RouteContext::RESOURCE => __DIR__.'/../Resources/specifications/json-request-body-validation-subscriber.json',
+            ]
+        );
 
         $exception = new Exception('This message should not be visible.');
         $event = $this->createExceptionEvent($request, $exception);

--- a/tests/Functional/App/Controller/GetPetController.php
+++ b/tests/Functional/App/Controller/GetPetController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nijens\OpenapiBundle\Tests\Functional\App\Controller;
 
+use Nijens\OpenapiBundle\Routing\RouteContext;
 use Nijens\OpenapiBundle\Serialization\SerializationContextBuilderInterface;
 use Nijens\OpenapiBundle\Tests\Functional\App\Model\Pet;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -51,7 +52,7 @@ class GetPetController
 
         $serializationContext = $this->serializationContextBuilder->getContextForSchemaObject(
             'Pet',
-            $request->attributes->get('_nijens_openapi')['openapi_resource']
+            $request->attributes->get(RouteContext::REQUEST_ATTRIBUTE)[RouteContext::RESOURCE]
         );
 
         return JsonResponse::fromJsonString(

--- a/tests/Functional/App/Controller/GetPetController.php
+++ b/tests/Functional/App/Controller/GetPetController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nijens\OpenapiBundle\Tests\Functional\App\Controller;
 
+use Nijens\OpenapiBundle\Serialization\SerializationContextBuilderInterface;
 use Nijens\OpenapiBundle\Tests\Functional\App\Model\Pet;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,17 +32,30 @@ class GetPetController
      */
     private $serializer;
 
-    public function __construct(SerializerInterface $serializer)
-    {
+    /**
+     * @var SerializationContextBuilderInterface
+     */
+    private $serializationContextBuilder;
+
+    public function __construct(
+        SerializerInterface $serializer,
+        SerializationContextBuilderInterface $serializationContextBuilder
+    ) {
         $this->serializer = $serializer;
+        $this->serializationContextBuilder = $serializationContextBuilder;
     }
 
     public function __invoke(Request $request): JsonResponse
     {
         $pet = new Pet(1, 'Cat');
 
+        $serializationContext = $this->serializationContextBuilder->getContextForSchemaObject(
+            'Pet',
+            $request->attributes->get('_nijens_openapi')['openapi_resource']
+        );
+
         return JsonResponse::fromJsonString(
-            $this->serializer->serialize($pet, 'json')
+            $this->serializer->serialize($pet, 'json', $serializationContext)
         );
     }
 }

--- a/tests/Functional/App/Controller/GetPetController.php
+++ b/tests/Functional/App/Controller/GetPetController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Functional\App\Controller;
+
+use Nijens\OpenapiBundle\Tests\Functional\App\Model\Pet;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Controller for functional testing the successful serialization of an object based on a schema object of
+ * the OpenAPI specification.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class GetPetController
+{
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    public function __construct(SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $pet = new Pet(1, 'Cat');
+
+        return JsonResponse::fromJsonString(
+            $this->serializer->serialize($pet, 'json')
+        );
+    }
+}

--- a/tests/Functional/App/Model/Pet.php
+++ b/tests/Functional/App/Model/Pet.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Functional\App\Model;
+
+class Pet
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $status = 'available';
+
+    /**
+     * @var string[]
+     */
+    private $photoUrls;
+
+    public function __construct(int $id, string $name, array $photoUrls = [])
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->photoUrls = $photoUrls;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPhotoUrls(): array
+    {
+        return $this->photoUrls;
+    }
+
+    public function getNotVisible(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Functional/App/config.yaml
+++ b/tests/Functional/App/config.yaml
@@ -6,6 +6,8 @@ framework:
         utf8: true
         strict_requirements: true
 
+    serializer: ~
+
     session:
         handler_id: ~
         # storage_id: session.storage.mock_file
@@ -20,3 +22,9 @@ services:
         arguments:
             - ~
             - '%kernel.logs_dir%/%kernel.environment%.log'
+
+    Nijens\OpenapiBundle\Tests\Functional\App\Controller\GetPetController:
+        arguments:
+            - '@Symfony\Component\Serializer\SerializerInterface'
+        tags:
+            - 'controller.service_arguments'

--- a/tests/Functional/App/config.yaml
+++ b/tests/Functional/App/config.yaml
@@ -26,5 +26,6 @@ services:
     Nijens\OpenapiBundle\Tests\Functional\App\Controller\GetPetController:
         arguments:
             - '@Symfony\Component\Serializer\SerializerInterface'
+            - '@Nijens\OpenapiBundle\Serialization\SerializationContextBuilderInterface'
         tags:
             - 'controller.service_arguments'

--- a/tests/Functional/App/openapi.yaml
+++ b/tests/Functional/App/openapi.yaml
@@ -178,6 +178,7 @@ paths:
                       - read:pets
     /pet/{petId}:
         get:
+            x-symfony-controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\GetPetController'
             tags:
                 - pet
             summary: Find pet by ID

--- a/tests/Functional/SerializationTest.php
+++ b/tests/Functional/SerializationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class SerializationTest extends WebTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    public function testCanSerializeObjectWithOpenApiSchemaObject(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/api/pet/1');
+
+        static::assertResponseIsSuccessful();
+
+        $responseBody = $this->client->getResponse()->getContent();
+
+        static::assertJson($responseBody);
+        static::assertJsonStringEqualsJsonString(
+            '{"id":1,"name":"Cat","photoUrls":[],"status":"available"}',
+            $responseBody
+        );
+    }
+}

--- a/tests/Json/SchemaLoaderMock.php
+++ b/tests/Json/SchemaLoaderMock.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Json;
+
+use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
+use stdClass;
+use Symfony\Component\Config\Resource\ResourceInterface;
+
+class SchemaLoaderMock implements SchemaLoaderInterface
+{
+    private $schema;
+
+    public function setSchema(stdClass $schema): void
+    {
+        $this->schema = $schema;
+    }
+
+    public function load(string $file): stdClass
+    {
+        return $this->schema;
+    }
+
+    public function getFileResource(string $file): ?ResourceInterface
+    {
+        return null;
+    }
+}

--- a/tests/Routing/RouteLoaderTest.php
+++ b/tests/Routing/RouteLoaderTest.php
@@ -20,6 +20,7 @@ use Nijens\OpenapiBundle\Json\Loader\ChainLoader;
 use Nijens\OpenapiBundle\Json\Loader\JsonLoader;
 use Nijens\OpenapiBundle\Json\Loader\YamlLoader;
 use Nijens\OpenapiBundle\Json\SchemaLoader;
+use Nijens\OpenapiBundle\Routing\RouteContext;
 use Nijens\OpenapiBundle\Routing\RouteLoader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
@@ -74,7 +75,7 @@ class RouteLoaderTest extends TestCase
         $this->assertSame([Request::METHOD_GET], $route->getMethods());
         $this->assertSame(
             __DIR__.'/../Resources/specifications/route-loader-minimal.json',
-            $route->getDefaults()['_nijens_openapi']['openapi_resource']
+            $route->getDefaults()[RouteContext::REQUEST_ATTRIBUTE][RouteContext::RESOURCE]
         );
     }
 
@@ -92,7 +93,7 @@ class RouteLoaderTest extends TestCase
         $this->assertSame([Request::METHOD_GET], $route->getMethods());
         $this->assertSame(
             __DIR__.'/../Resources/specifications/route-loader-minimal.yaml',
-            $route->getDefaults()['_nijens_openapi']['openapi_resource']
+            $route->getDefaults()[RouteContext::REQUEST_ATTRIBUTE][RouteContext::RESOURCE]
         );
     }
 
@@ -110,7 +111,7 @@ class RouteLoaderTest extends TestCase
         $this->assertSame([Request::METHOD_GET], $route->getMethods());
         $this->assertSame(
             __DIR__.'/../Resources/specifications/route-loader-minimal.yml',
-            $route->getDefaults()['_nijens_openapi']['openapi_resource']
+            $route->getDefaults()[RouteContext::REQUEST_ATTRIBUTE][RouteContext::RESOURCE]
         );
     }
 
@@ -124,7 +125,7 @@ class RouteLoaderTest extends TestCase
     }
 
     /**
-     * Tests if {@see RouteLoader::load} adds a 'openapi_json_request_validation_pointer' option
+     * Tests if {@see RouteLoader::load} adds a {@see RouteContext::JSON_REQUEST_VALIDATION_POINTER} option
      * when the request body of an operation can be validated.
      *
      * @depends testLoadMinimalFromJson
@@ -137,7 +138,7 @@ class RouteLoaderTest extends TestCase
         $this->assertInstanceOf(Route::class, $route);
         $this->assertSame(
             '/paths/~1pets/put/requestBody/content/application~1json/schema',
-            $route->getDefaults()['_nijens_openapi']['openapi_json_request_validation_pointer']
+            $route->getDefaults()[RouteContext::REQUEST_ATTRIBUTE][RouteContext::JSON_REQUEST_VALIDATION_POINTER]
         );
     }
 

--- a/tests/Serialization/SerializationContextBuilderTest.php
+++ b/tests/Serialization/SerializationContextBuilderTest.php
@@ -153,6 +153,50 @@ class SerializationContextBuilderTest extends TestCase
         );
     }
 
+    public function testCanCreateContextForCombinedObjectSchema(): void
+    {
+        $schema = $this->convertToObject([
+            'components' => [
+                'schemas' => [
+                    'Pet' => [
+                        'allOf' => [
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    'id' => [
+                                        'type' => 'integer',
+                                        'format' => 'int64',
+                                    ],
+                                ],
+                            ],
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    'name' => [
+                                        'type' => 'string',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->schemaLoader->setSchema($schema);
+
+        $this->assertSame(
+            [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+                AbstractNormalizer::ATTRIBUTES => [
+                    'id',
+                    'name',
+                ],
+            ],
+            $this->serializationContextBuilder->getContextForSchemaObject('Pet', '')
+        );
+    }
+
     private function convertToObject(array $schema): stdClass
     {
         return json_decode(json_encode($schema));

--- a/tests/Serialization/SerializationContextBuilderTest.php
+++ b/tests/Serialization/SerializationContextBuilderTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Serialization;
+
+use Nijens\OpenapiBundle\Json\Reference;
+use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
+use Nijens\OpenapiBundle\Serialization\SerializationContextBuilder;
+use Nijens\OpenapiBundle\Tests\Json\SchemaLoaderMock;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+
+/**
+ * Tests the {@see SerializationContextBuilder}.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class SerializationContextBuilderTest extends TestCase
+{
+    /**
+     * @var SerializationContextBuilder
+     */
+    private $serializationContextBuilder;
+
+    /**
+     * @var SchemaLoaderInterface|SchemaLoaderMock
+     */
+    private $schemaLoader;
+
+    protected function setUp(): void
+    {
+        $this->schemaLoader = new SchemaLoaderMock();
+
+        $this->serializationContextBuilder = new SerializationContextBuilder($this->schemaLoader);
+    }
+
+    public function testCanCreateContextForObjectSchema(): void
+    {
+        $schema = $this->convertToObject([
+            'components' => [
+                'schemas' => [
+                    'Pet' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'name' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->schemaLoader->setSchema($schema);
+
+        $this->assertSame(
+            [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+                AbstractNormalizer::ATTRIBUTES => [
+                    'name',
+                ],
+            ],
+            $this->serializationContextBuilder->getContextForSchemaObject('Pet', '')
+        );
+    }
+
+    public function testCanCreateContextForObjectSchemaWithReference(): void
+    {
+        $schema = $this->convertToObject([
+            'components' => [
+                'schemas' => [
+                    'Pet' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'name' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                    ],
+                    'Human' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'firstName' => [
+                                'type' => 'string',
+                            ],
+                            'lastName' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $schema->components->schemas->Pet->properties->owner = new Reference('#/components/schemas/Human', $schema);
+
+        $this->schemaLoader->setSchema($schema);
+
+        $this->assertSame(
+            [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+                AbstractNormalizer::ATTRIBUTES => [
+                    'name',
+                    'owner' => [
+                        'firstName',
+                        'lastName',
+                    ],
+                ],
+            ],
+            $this->serializationContextBuilder->getContextForSchemaObject('Pet', '')
+        );
+    }
+
+    public function testCanCreateContextForArraySchema(): void
+    {
+        $schema = $this->convertToObject([
+            'components' => [
+                'schemas' => [
+                    'PetList' => [
+                        'type' => 'array',
+                        'items' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'name' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->schemaLoader->setSchema($schema);
+
+        $this->assertSame(
+            [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+                AbstractNormalizer::ATTRIBUTES => [
+                    'name',
+                ],
+            ],
+            $this->serializationContextBuilder->getContextForSchemaObject('PetList', '')
+        );
+    }
+
+    private function convertToObject(array $schema): stdClass
+    {
+        return json_decode(json_encode($schema));
+    }
+}

--- a/tests/Serialization/SerializationContextBuilderTest.php
+++ b/tests/Serialization/SerializationContextBuilderTest.php
@@ -197,6 +197,47 @@ class SerializationContextBuilderTest extends TestCase
         );
     }
 
+    public function testCanCreateContextForUnimplementedJsonSchemaKeywordsWithoutErrors(): void
+    {
+        $schema = $this->convertToObject([
+            'components' => [
+                'schemas' => [
+                    'Pet' => [
+                        'oneOf' => [
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    'id' => [
+                                        'type' => 'integer',
+                                        'format' => 'int64',
+                                    ],
+                                ],
+                            ],
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    'name' => [
+                                        'type' => 'string',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->schemaLoader->setSchema($schema);
+
+        $this->assertSame(
+            [
+                AbstractObjectNormalizer::SKIP_NULL_VALUES => true,
+                AbstractNormalizer::ATTRIBUTES => [],
+            ],
+            $this->serializationContextBuilder->getContextForSchemaObject('Pet', '')
+        );
+    }
+
     private function convertToObject(array $schema): stdClass
     {
         return json_decode(json_encode($schema));


### PR DESCRIPTION
This PR adds a `SerializationContextBuilder` service which allows you to provide the Symfony Serializer with a serialization context based on your OpenAPI specification.

#### Example controller implementation
```php
class ExampleController
{
    public function __invoke(
        Request $request, 
        SerializerInterface $serializer, 
        SerializationContextBuilder $serializationContextBuilder
    ): JsonResponse {
        $serializationContext = $serializationContextBuilder->getContextForSchemaObject(
            'Pet',
            $request->attributes->get(RouteContext::REQUEST_ATTRIBUTE)[RouteContext::RESOURCE] // The filepath to your OpenAPI specification provided by the routing.
        );
        
        return JsonResponse::fromJsonString(
            $serializer->serialize($pet, 'json', $serializationContext)
        );
    }
}
```