### PR TITLE
Fix creating a serialization context when referencing a combined schema object

### DIFF
--- a/src/Serialization/SerializationContextBuilder.php
+++ b/src/Serialization/SerializationContextBuilder.php
@@ -132,6 +132,15 @@ class SerializationContextBuilder implements SerializationContextBuilderInterfac
     private function isType($schemaObject, string $type): bool
     {
         $schemaObject = $this->dereference($schemaObject);
+        if (isset($schemaObject->allOf)) {
+            foreach ($schemaObject->allOf as $allOfSchemaObject) {
+                if ($this->isType($allOfSchemaObject, $type)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         return $schemaObject->type === $type;
     }


### PR DESCRIPTION
This PR fixes an `Undefined property: stdClass::$type` error when a combined schema object created with `allOf` is referenced from another schema object.