### PR TITLE
Fix validation of constraints in reference objects within a JSON schema

### DIFF
--- a/src/Json/Exception/InvalidArgumentException.php
+++ b/src/Json/Exception/InvalidArgumentException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Json\Exception;
+
+use InvalidArgumentException as BaseInvalidArgumentException;
+
+class InvalidArgumentException extends BaseInvalidArgumentException
+{
+}

--- a/tests/Functional/App/openapi.yaml
+++ b/tests/Functional/App/openapi.yaml
@@ -226,6 +226,8 @@ components:
           format: int64
         name:
           type: string
+      required:
+        - name
       xml:
         name: Category
 

--- a/tests/Functional/ValidationResponsesTest.php
+++ b/tests/Functional/ValidationResponsesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Nijens\OpenapiBundle\Tests\Functional;
 
+use stdClass;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -101,6 +102,41 @@ class ValidationResponsesTest extends WebTestCase
         self::assertJsonStringEqualsJsonString(
             json_encode($expectedJsonResponseBody),
             $response->getContent()
+        );
+    }
+
+    public function testInvalidNestedRequestBodyReturnsUnprocessableEntityResponse(): void
+    {
+        $jsonRequestBody = [
+            'name' => 'Cat',
+            'photoUrls' => [
+                'https://example.com/photos/cat.jpg',
+            ],
+            'category' => new stdClass(),
+        ];
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/pets',
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            json_encode($jsonRequestBody)
+        );
+
+        $expectedJsonResponseBody = [
+            'message' => 'Validation of JSON request body failed.',
+            'errors' => [
+                'The property name is required',
+            ],
+        ];
+
+        static::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        static::assertJsonStringEqualsJsonString(
+            json_encode($expectedJsonResponseBody),
+            $this->client->getResponse()->getContent()
         );
     }
 

--- a/tests/Json/ReferenceTest.php
+++ b/tests/Json/ReferenceTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Json;
+
+use Nijens\OpenapiBundle\Json\Exception\InvalidArgumentException;
+use Nijens\OpenapiBundle\Json\Reference;
+use PHPUnit\Framework\TestCase;
+
+class ReferenceTest extends TestCase
+{
+    /**
+     * @var Reference
+     */
+    private $reference;
+
+    private $jsonSchema;
+
+    protected function setUp(): void
+    {
+        $this->jsonSchema = (object) [
+            'foo' => (object) [
+                'type' => 'object',
+                'properties' => (object) [
+                    'bar' => (object) [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'components' => (object) [
+                'baz' => (object) [
+                    'type' => 'object',
+                    'properties' => (object) [
+                        'qux' => (object) [
+                            'type' > 'string',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->reference = new Reference('#/foo', $this->jsonSchema);
+    }
+
+    public function testCanGetPointer(): void
+    {
+        static::assertSame('#/foo', $this->reference->getPointer());
+    }
+
+    public function testCanGetJsonSchema(): void
+    {
+        static::assertSame($this->jsonSchema, $this->reference->getJsonSchema());
+    }
+
+    /**
+     * @dataProvider provideResolveTestCases
+     */
+    public function testCanResolvePointerInJsonSchema(string $pointer, $expectedResult): void
+    {
+        $reference = new Reference($pointer, $this->jsonSchema);
+
+        static::assertEquals($expectedResult, $reference->resolve());
+    }
+
+    public function testCanCheckExistenceOfProperty(): void
+    {
+        static::assertTrue($this->reference->has('type'));
+        static::assertFalse($this->reference->has('required'));
+    }
+
+    public function testCanCheckExistenceOfPropertyThroughIssetMagicMethodProxy(): void
+    {
+        static::assertTrue(isset($this->reference->type));
+        static::assertFalse(isset($this->reference->required));
+    }
+
+    public function testCanGetProperty(): void
+    {
+        static::assertSame('object', $this->reference->get('type'));
+    }
+
+    public function testCanGetPropertyThroughGetMagicMethodProxy(): void
+    {
+        static::assertSame('object', $this->reference->type);
+    }
+
+    public function testCannotGetNonExistingProperty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown property "required".');
+
+        $this->reference->get('required');
+    }
+
+    public function testCannotGetNonExistingPropertyThroughGetMagicMethodProxy(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown property "required".');
+
+        $this->reference->required;
+    }
+
+    public function testCanJsonSerializeToJsonReferenceObject(): void
+    {
+        static::assertJsonStringEqualsJsonString('{"$ref": "#/foo"}', json_encode($this->reference));
+    }
+
+    public function provideResolveTestCases(): iterable
+    {
+        yield [
+            '#/foo',
+            (object) [
+                'type' => 'object',
+                'properties' => (object) [
+                    'bar' => (object) [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            '#/components/baz',
+            (object) [
+                'type' => 'object',
+                'properties' => (object) [
+                    'qux' => (object) [
+                        'type' > 'string',
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
The `SchemaLoader`, besides loading the OpenAPI document, also handles dereferencing of the JSON schema [reference objects](https://spec.openapis.org/oas/v3.1.0#reference-object) (`$ref`) into `Nijens\OpenapiBundle\Json\Reference` instances. These reference instances should have allowed walking through the JSON schema without creating circular references within the deserialized JSON. Yet, the implementation lacked the actual walking through the JSON schema.

The external JSON schema validator library the bundle uses also didn't give a heads-up and ignored the reference instances. Therefore missing JSON schema constraints in the request body validation.
```yaml
requestBody:
  application/json:
    schema:
      type: object
      properties:
        name:
          type: string
        category:
          # Constraints (eg. required fields) inside this object would not be validated.
          $ref: '#/components/schema/Category'
```

This PR fixes walking through reference instances and therefore fix the validation.