### PR TITLE
Deprecate x-symfony-controller specification extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "seld/jsonlint": "^1.7",
         "symfony/config": "^4.4 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
+        "symfony/deprecation-contracts": "^2.5 || ^3.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
         "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
         "symfony/http-foundation": "^4.4 || ^5.0 || ^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -903,25 +903,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.2.0",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3"
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/1ee04c65529dea5d8744774d474e7cbd2f1206d3",
-                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -950,7 +950,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -966,7 +966,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T10:21:52+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/error-handler",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8efa4da0ffcb2d3216269d01d1b38eba",
+    "content-hash": "07987aa9eea855cc51f2660e9a762f59",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -903,25 +903,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.1",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
+                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/1ee04c65529dea5d8744774d474e7cbd2f1206d3",
+                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -950,7 +950,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.0"
             },
             "funding": [
                 {
@@ -966,7 +966,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-11-25T10:21:52+00:00"
         },
         {
             "name": "symfony/error-handler",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,6 @@
 
     <php>
         <server name="KERNEL_CLASS" value="Nijens\OpenapiBundle\Tests\Functional\App\Kernel"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=15&amp;max[indirect]=4"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=15&amp;max[self]=39&amp;max[indirect]=4"/>
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,6 @@
 
     <php>
         <server name="KERNEL_CLASS" value="Nijens\OpenapiBundle\Tests\Functional\App\Kernel"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=15&amp;max[self]=39&amp;max[indirect]=4"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=15&amp;max[self]=40&amp;max[indirect]=4"/>
     </php>
 </phpunit>

--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Nijens\OpenapiBundle\Routing;
 
 use Nijens\OpenapiBundle\Controller\CatchAllController;
+use Nijens\OpenapiBundle\DependencyInjection\Configuration;
 use Nijens\OpenapiBundle\Json\JsonPointer;
 use Nijens\OpenapiBundle\Json\SchemaLoaderInterface;
 use stdClass;
@@ -161,6 +162,12 @@ class RouteLoader extends FileLoader
         }
 
         if (isset($defaults['_controller']) === false && isset($operation->{'x-symfony-controller'})) {
+            trigger_deprecation(
+                Configuration::BUNDLE_NAME,
+                '1.5',
+                'Using the "x-symfony-controller" specification extension is deprecated and will be removed in 2.0. Please use the "x-openapi-bundle" specification extension instead.'
+            );
+
             $defaults['_controller'] = $operation->{'x-symfony-controller'};
         }
 


### PR DESCRIPTION
This PR deprecates the `x-symfony-controller` specification extension as it has been replaced with the `x-openapi-bundle` specification extension.