### PR TITLE
Change priority of kernel exception subscribers to be able to process security exceptions

### DIFF
--- a/src/ExceptionHandling/EventSubscriber/ProblemExceptionToJsonResponseSubscriber.php
+++ b/src/ExceptionHandling/EventSubscriber/ProblemExceptionToJsonResponseSubscriber.php
@@ -36,7 +36,7 @@ final class ProblemExceptionToJsonResponseSubscriber implements EventSubscriberI
     {
         return [
             KernelEvents::EXCEPTION => [
-                ['onKernelExceptionCreateJsonResponse', 0],
+                ['onKernelExceptionCreateJsonResponse', -32],
             ],
         ];
     }

--- a/src/ExceptionHandling/EventSubscriber/ThrowableToProblemExceptionSubscriber.php
+++ b/src/ExceptionHandling/EventSubscriber/ThrowableToProblemExceptionSubscriber.php
@@ -38,7 +38,7 @@ final class ThrowableToProblemExceptionSubscriber implements EventSubscriberInte
     {
         return [
             KernelEvents::EXCEPTION => [
-                ['onKernelExceptionTransformToProblemException', 10],
+                ['onKernelExceptionTransformToProblemException', -16],
             ],
         ];
     }


### PR DESCRIPTION
This change is necessary to fix transforming security exceptions to `ProblemException` instances.

Symfony's `ErrorListener` converts eg. an `AccessDeniedException` to an `AccessDeniedHttpException` even though the exception is already transformed to a `ProblemException` instance.

By changing the priority of the subscribers to execute after Symfony's `ErrorListener` the `AccessDeniedHttpException` (instead of the `AccessDeniedException`) is transformed to `ProblemException` instance and then successfully converted to a response.