### PR TITLE
Remove Symfony 4.4, 5.0, 5.1, 5.2 and 5.3 support

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             matrix:
                 php-version: ['7.4', '8.0', '8.1', '8.2', '8.3']
-                symfony-version: ['4.4', '5.0', '5.1', '5.2', '5.3', '5.4', '6.0', '6.1', '6.2', '6.3', '6.4']
+                symfony-version: ['5.4', '6.0', '6.1', '6.2', '6.3', '6.4']
                 test-options: ['']
                 coverage: [false]
                 include:
@@ -32,8 +32,6 @@ jobs:
                     - php-version: '7.4'
                       symfony-version: '6.4'
                     - php-version: '8.0'
-                      symfony-version: '5.0'
-                    - php-version: '8.0'
                       symfony-version: '6.1'
                     - php-version: '8.0'
                       symfony-version: '6.2'
@@ -41,24 +39,6 @@ jobs:
                       symfony-version: '6.3'
                     - php-version: '8.0'
                       symfony-version: '6.4'
-                    - php-version: '8.1'
-                      symfony-version: '5.0'
-                    - php-version: '8.1'
-                      symfony-version: '5.1'
-                    - php-version: '8.1'
-                      symfony-version: '5.2'
-                    - php-version: '8.2'
-                      symfony-version: '5.0'
-                    - php-version: '8.2'
-                      symfony-version: '5.1'
-                    - php-version: '8.2'
-                      symfony-version: '5.2'
-                    - php-version: '8.3'
-                      symfony-version: '5.0'
-                    - php-version: '8.3'
-                      symfony-version: '5.1'
-                    - php-version: '8.3'
-                      symfony-version: '5.2'
 
         steps:
             - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -10,32 +10,32 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "justinrainbow/json-schema": "^5.2",
         "league/uri": "^6.3",
         "seld/jsonlint": "^1.7",
-        "symfony/config": "^4.4 || ^5.0 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
+        "symfony/config": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/deprecation-contracts": "^2.5 || ^3.0",
-        "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-foundation": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
-        "symfony/property-access": "^4.4 || ^5.0 || ^6.0",
-        "symfony/routing": "^4.4 || ^5.0 || ^6.0",
-        "symfony/serializer": "^4.4 || ^5.0 || ^6.0",
-        "symfony/yaml": "^4.4 || ^5.0 || ^6.0"
+        "symfony/event-dispatcher": "^5.4 || ^6.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0",
+        "symfony/http-foundation": "^5.4 || ^6.0",
+        "symfony/http-kernel": "^5.4 || ^6.0",
+        "symfony/property-access": "^5.4 || ^6.0",
+        "symfony/routing": "^5.4 || ^6.0",
+        "symfony/serializer": "^5.4 || ^6.0",
+        "symfony/yaml": "^5.4 || ^6.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "masterminds/html5": "^2.7",
         "monolog/monolog": "^1.27 || ^2.6 || ^3.0",
-        "phpunit/phpunit": "^9.3",
-        "symfony/browser-kit": "^4.4 || ^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0 || ^6.0",
-        "symfony/process": "^4.4 || ^5.0 || ^6.0",
-        "symfony/security-bundle": "^4.4 || ^5.0 || ^6.0"
+        "phpunit/phpunit": "^9.6",
+        "symfony/browser-kit": "^5.4 || ^6.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0",
+        "symfony/process": "^5.4 || ^6.0",
+        "symfony/security-bundle": "^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31ae82d11329b7379f8afa697e7eefec",
+    "content-hash": "004a637e7699c6f622c3fc0dd68fe537",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -3284,16 +3284,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.52.0",
+            "version": "v3.52.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "a3564bd66f4bce9bc871ef18b690e2dc67a7f969"
+                "reference": "6e77207f0d851862ceeb6da63e6e22c01b1587bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a3564bd66f4bce9bc871ef18b690e2dc67a7f969",
-                "reference": "a3564bd66f4bce9bc871ef18b690e2dc67a7f969",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/6e77207f0d851862ceeb6da63e6e22c01b1587bc",
+                "reference": "6e77207f0d851862ceeb6da63e6e22c01b1587bc",
                 "shasum": ""
             },
             "require": {
@@ -3364,7 +3364,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.52.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.52.1"
             },
             "funding": [
                 {
@@ -3372,7 +3372,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-18T18:40:11+00:00"
+            "time": "2024-03-19T21:02:43+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -6238,7 +6238,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
Remove support for End-Of-Life Symfony versions in preparation for version 2.