### PR TITLE
Prevent the Symfony Router from resolving %-characters in an OpenAPI document as service container parameters

### DIFF
--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -210,7 +210,12 @@ class RouteLoader extends FileLoader
         }
 
         if (isset($operation->requestBody->content->{'application/json'}->schema)) {
-            $openapiRouteContext[RouteContext::REQUEST_BODY_SCHEMA] = serialize($operation->requestBody->content->{'application/json'}->schema);
+            // Escape %-characters to prevent the router from interpreting them as service container parameters.
+            $openapiRouteContext[RouteContext::REQUEST_BODY_SCHEMA] = str_replace(
+                '%',
+                '%%',
+                serialize($operation->requestBody->content->{'application/json'}->schema)
+            );
         }
 
         if (isset($operation->requestBody->content->{'application/json'})) {

--- a/tests/Functional/App/openapi.yaml
+++ b/tests/Functional/App/openapi.yaml
@@ -6,6 +6,9 @@ info:
 paths:
   /pets:
     get:
+      description: |
+        This description contains a test if %abc% is not attempted to be resolved as
+        Symfony service container parameter.
       x-openapi-bundle:
         controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\GetPetsController'
         additionalRouteAttributes:


### PR DESCRIPTION
Parts of the OpenAPI document are loaded as route attributes by the RouteLoader. The Symfony Router attempts to parse each attribute of a loaded route, checking for %-characters. When found, it tries to resolve them as service container parameters, throwing an exception if the parameter is not found.

This PR resolves the issue by preventing the resolution process, escaping %-characters by doubling them.