### PR TITLE
Add Symfony route parameter validation based on OpenAPI path parameters

### DIFF
--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -253,7 +253,7 @@ class RouteLoader extends FileLoader
             $format = $parameterSchema->format ?? null;
             $pattern = $parameterSchema->pattern ?? null;
 
-            $requirements[$parameter->name] = match($type) {
+            $requirements[$parameter->name] = match ($type) {
                 'boolean' => '(?:true|false)',
                 'integer' => '-?\d+',
                 'number' => '-?(?:\d+)(?:\.\d+)?(?:[eE][+-]?\d+)?',

--- a/tests/Functional/App/Controller/SuccessController.php
+++ b/tests/Functional/App/Controller/SuccessController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Functional\App\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Controller for functional testing that always returns a 200 OK response.
+ *
+ * @author Niels Nijens <nijens.niels@gmail.com>
+ */
+class SuccessController
+{
+    public function __invoke(): Response
+    {
+        return new Response('', Response::HTTP_OK);
+    }
+}

--- a/tests/Functional/App/config.yaml
+++ b/tests/Functional/App/config.yaml
@@ -71,6 +71,10 @@ services:
       tags:
         - 'controller.service_arguments'
 
+    Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController:
+      tags:
+        - 'controller.service_arguments'
+
     Nijens\OpenapiBundle\Tests\Functional\App\Controller\UpdatePetController:
         arguments:
             - '@Symfony\Component\Serializer\SerializerInterface'

--- a/tests/Functional/App/openapi.yaml
+++ b/tests/Functional/App/openapi.yaml
@@ -147,6 +147,165 @@ paths:
         schema:
           type: integer
           format: int64
+        x-openapi-bundle-deserialize-as: 'id'
+
+  /validate-path/boolean/{boolean}:
+    get:
+      operationId: validatePathBoolean
+      summary: Endpoint to validate path parameter requirement.
+      x-openapi-bundle:
+        controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController'
+      responses:
+        '200':
+          description: Success!
+
+    parameters:
+      - name: boolean
+        in: path
+        required: true
+        schema:
+          type: boolean
+
+  /validate-path/integer/{integer}:
+    get:
+      operationId: validatePathInteger
+      summary: Endpoint to validate path parameter requirement.
+      x-openapi-bundle:
+        controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController'
+      responses:
+        '200':
+          description: Success!
+
+    parameters:
+      - name: integer
+        in: path
+        required: true
+        schema:
+          type: integer
+
+  /validate-path/number/{number}:
+    get:
+      operationId: validatePathNumber
+      summary: Endpoint to validate path parameter requirement.
+      x-openapi-bundle:
+        controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController'
+      responses:
+        '200':
+          description: Success!
+
+    parameters:
+      - name: number
+        in: path
+        required: true
+        schema:
+          type: number
+
+  /validate-path/string/date/{date}:
+    get:
+      operationId: validatePathStringDate
+      summary: Endpoint to validate path parameter requirement.
+      x-openapi-bundle:
+        controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController'
+      responses:
+        '200':
+          description: Success!
+
+    parameters:
+      - name: date
+        in: path
+        required: true
+        schema:
+          type: string
+          format: date
+
+  /validate-path/string/date-time/{dateTime}:
+    get:
+      operationId: validatePathStringDateTime
+      summary: Endpoint to validate path parameter requirement.
+      x-openapi-bundle:
+        controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController'
+      responses:
+        '200':
+          description: Success!
+
+    parameters:
+      - name: dateTime
+        in: path
+        required: true
+        schema:
+          type: string
+          format: date-time
+
+  /validate-path/string/email/{email}:
+    get:
+      operationId: validatePathStringEmail
+      summary: Endpoint to validate path parameter requirement.
+      x-openapi-bundle:
+        controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController'
+      responses:
+        '200':
+          description: Success!
+
+    parameters:
+      - name: email
+        in: path
+        required: true
+        schema:
+          type: string
+          format: email
+
+  /validate-path/string/uuid/{uuid}:
+    get:
+      operationId: validatePathStringUuid
+      summary: Endpoint to validate path parameter requirement.
+      x-openapi-bundle:
+        controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController'
+      responses:
+        '200':
+          description: Success!
+
+    parameters:
+      - name: uuid
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+  /validate-path/string/pattern/{stringPattern}:
+    get:
+      operationId: validatePathStringPattern
+      summary: Endpoint to validate path parameter requirement.
+      x-openapi-bundle:
+        controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController'
+      responses:
+        '200':
+          description: Success!
+
+    parameters:
+      - name: stringPattern
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: '[A-Z]{2}'
+
+  /validate-path/string/{string}:
+    get:
+      operationId: validatePathString
+      summary: Endpoint to validate path parameter requirement.
+      x-openapi-bundle:
+        controller: 'Nijens\OpenapiBundle\Tests\Functional\App\Controller\SuccessController'
+      responses:
+        '200':
+          description: Success!
+
+    parameters:
+      - name: string
+        in: path
+        required: true
+        schema:
+          type: string
 
   /authenticated/pets:
     post:

--- a/tests/Functional/RoutePathParameterValidationTest.php
+++ b/tests/Functional/RoutePathParameterValidationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the OpenapiBundle package.
+ *
+ * (c) Niels Nijens <nijens.niels@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Nijens\OpenapiBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RoutePathParameterValidationTest extends WebTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+    }
+
+    /**
+     * @dataProvider provideTestCases
+     */
+    public function testCanValidateString(string $path, string $parameter, int $expectedStatusCode): void
+    {
+        $this->client->request(Request::METHOD_GET, sprintf($path, $parameter));
+
+        static::assertResponseStatusCodeSame($expectedStatusCode);
+    }
+
+    public static function provideTestCases(): array
+    {
+        return [
+            ['/api/validate-path/boolean/%s', 'true', Response::HTTP_OK],
+            ['/api/validate-path/boolean/%s', 'false', Response::HTTP_OK],
+            ['/api/validate-path/boolean/%s', 'no', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/integer/%s', '1', Response::HTTP_OK],
+            ['/api/validate-path/integer/%s', '1.0', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/integer/%s', 'abc', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/number/%s', '1', Response::HTTP_OK],
+            ['/api/validate-path/number/%s', '1.0', Response::HTTP_OK],
+            ['/api/validate-path/number/%s', 'abc', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/string/date/%s', '2026-01-19', Response::HTTP_OK],
+            ['/api/validate-path/string/date/%s', 'abc', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/string/date-time/%s', '2026-01-19T12:34:56Z', Response::HTTP_OK],
+            ['/api/validate-path/string/date-time/%s', '1', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/string/date-time/%s', 'abc', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/string/email/%s', 'john@doe.com', Response::HTTP_OK],
+            ['/api/validate-path/string/email/%s', 'abc', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/string/uuid/%s', '5f89d86d-4ead-4bc6-ba3e-61726d22fe13', Response::HTTP_OK],
+            ['/api/validate-path/string/uuid/%s', '1', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/string/uuid/%s', 'abc', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/string/pattern/%s', 'NL', Response::HTTP_OK],
+            ['/api/validate-path/string/pattern/%s', 'ab', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/string/pattern/%s', 'abc', Response::HTTP_NOT_FOUND],
+            ['/api/validate-path/string/%s', '1', Response::HTTP_OK],
+            ['/api/validate-path/string/%s', 'abc', Response::HTTP_OK],
+            ['/api/validate-path/string/%s', 'abc/abc', Response::HTTP_NOT_FOUND],
+        ];
+    }
+}


### PR DESCRIPTION
This PR enables Symfony route parameter validation by translating path parameter constraints defined in the OpenAPI specification into Symfony route requirements.

The current implementation supports the following OpenAPI parameter types and formats:

* `boolean`
* `integer`
* `number`
* `string` with the formats `date`, `date-time`, `email`, and `uuid`
* `string` parameters with an explicit `pattern` defined in the OpenAPI document

This allows route-level validation to be automatically derived from the API specification, ensuring better consistency and earlier validation failures.

For more details on Symfony route parameter validation, see:
[https://symfony.com/doc/current/routing.html#parameters-validation](https://symfony.com/doc/current/routing.html#parameters-validation)