### PR TITLE
Fixed required check

### DIFF
--- a/src/Validation/RequestValidator/RequestParameterValidator.php
+++ b/src/Validation/RequestValidator/RequestParameterValidator.php
@@ -78,7 +78,7 @@ final class RequestParameterValidator implements ValidatorInterface
     private function validateQueryParameter(Request $request, string $parameterName, stdClass $parameter): array
     {
         $violations = [];
-        if ($request->query->has($parameterName) === false && $parameter->required ?? false) {
+        if (($parameter->required ?? false) && $request->query->has($parameterName) === false) {
             $violations[] = new Violation(
                 'required_query_parameter',
                 sprintf('Query parameter %s is required.', $parameterName),

--- a/src/Validation/RequestValidator/RequestParameterValidator.php
+++ b/src/Validation/RequestValidator/RequestParameterValidator.php
@@ -92,7 +92,10 @@ final class RequestParameterValidator implements ValidatorInterface
             return $violations;
         }
 
-        $parameterValue = $request->query->get($parameterName);
+        $parameterValue = $this->normalizeQueryParameterValue(
+            $request->query->get($parameterName),
+            $parameter->schema
+        );
 
         $this->jsonValidator->validate($parameterValue, $parameter->schema, Constraint::CHECK_MODE_COERCE_TYPES);
         if ($this->jsonValidator->isValid()) {
@@ -110,5 +113,24 @@ final class RequestParameterValidator implements ValidatorInterface
             },
             $validationErrors
         );
+    }
+
+    /**
+     * Normalizes query parameter values that Symfony exposes as strings.
+     *
+     * Boolean query parameters are commonly passed as `1`/`0` in URLs, but
+     * JsonSchema expects native booleans for a boolean schema.
+     */
+    private function normalizeQueryParameterValue(mixed $parameterValue, stdClass $schema): mixed
+    {
+        if (($schema->type ?? null) !== 'boolean' || is_string($parameterValue) === false) {
+            return $parameterValue;
+        }
+
+        return match (strtolower($parameterValue)) {
+            '1', 'true' => true,
+            '0', 'false' => false,
+            default => $parameterValue,
+        };
     }
 }

--- a/src/Validation/RequestValidator/RequestParameterValidator.php
+++ b/src/Validation/RequestValidator/RequestParameterValidator.php
@@ -92,10 +92,10 @@ final class RequestParameterValidator implements ValidatorInterface
             return $violations;
         }
 
-        $parameterValue = $this->normalizeQueryParameterValue(
-            $request->query->get($parameterName),
-            $parameter->schema
-        );
+        $parameterValue = $request->query->get($parameterName);
+        if ($schema->type === 'boolean') {
+          $parameterValue = $request->query->getBoolean($parameterName, $schema->default ?? false);
+        }
 
         $this->jsonValidator->validate($parameterValue, $parameter->schema, Constraint::CHECK_MODE_COERCE_TYPES);
         if ($this->jsonValidator->isValid()) {

--- a/src/Validation/RequestValidator/RequestParameterValidator.php
+++ b/src/Validation/RequestValidator/RequestParameterValidator.php
@@ -93,8 +93,8 @@ final class RequestParameterValidator implements ValidatorInterface
         }
 
         $parameterValue = $request->query->get($parameterName);
-        if ($schema->type === 'boolean') {
-          $parameterValue = $request->query->getBoolean($parameterName, $schema->default ?? false);
+        if ($parameter->schema->type === 'boolean') {
+            $parameterValue = $request->query->getBoolean($parameterName, $parameter->schema->default ?? false);
         }
 
         $this->jsonValidator->validate($parameterValue, $parameter->schema, Constraint::CHECK_MODE_COERCE_TYPES);
@@ -113,24 +113,5 @@ final class RequestParameterValidator implements ValidatorInterface
             },
             $validationErrors
         );
-    }
-
-    /**
-     * Normalizes query parameter values that Symfony exposes as strings.
-     *
-     * Boolean query parameters are commonly passed as `1`/`0` in URLs, but
-     * JsonSchema expects native booleans for a boolean schema.
-     */
-    private function normalizeQueryParameterValue(mixed $parameterValue, stdClass $schema): mixed
-    {
-        if (($schema->type ?? null) !== 'boolean' || is_string($parameterValue) === false) {
-            return $parameterValue;
-        }
-
-        return match (strtolower($parameterValue)) {
-            '1', 'true' => true,
-            '0', 'false' => false,
-            default => $parameterValue,
-        };
     }
 }

--- a/tests/Validation/RequestValidator/RequestParameterValidatorTest.php
+++ b/tests/Validation/RequestValidator/RequestParameterValidatorTest.php
@@ -91,6 +91,29 @@ class RequestParameterValidatorTest extends TestCase
         );
     }
 
+    public function testCanValidateOptionalRequestParameterWithoutRequiredFlag(): void
+    {
+        $request = new Request();
+        $request->attributes->set(
+            RouteContext::REQUEST_ATTRIBUTE,
+            [
+                RouteContext::REQUEST_VALIDATE_QUERY_PARAMETERS => [
+                    'foo' => json_encode([
+                        'name' => 'foo',
+                        'in' => 'query',
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                    ]),
+                ],
+            ]
+        );
+
+        static::assertNull(
+            $this->validator->validate($request)
+        );
+    }
+
     public function testCanValidateRequestParameterOfTypeBoolean(): void
     {
         $request = new Request();

--- a/tests/Validation/RequestValidator/RequestParameterValidatorTest.php
+++ b/tests/Validation/RequestValidator/RequestParameterValidatorTest.php
@@ -139,6 +139,31 @@ class RequestParameterValidatorTest extends TestCase
         );
     }
 
+    public function testCanValidateRequestParameterOfTypeBooleanWithOne(): void
+    {
+        $request = new Request();
+        $request->query->set('foo', '1');
+        $request->attributes->set(
+            RouteContext::REQUEST_ATTRIBUTE,
+            [
+                RouteContext::REQUEST_VALIDATE_QUERY_PARAMETERS => [
+                    'foo' => json_encode([
+                        'name' => 'foo',
+                        'in' => 'query',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'boolean',
+                        ],
+                    ]),
+                ],
+            ]
+        );
+
+        static::assertNull(
+            $this->validator->validate($request)
+        );
+    }
+
     public function testCanValidateRequestParameterOfTypeString(): void
     {
         $request = new Request();


### PR DESCRIPTION
1. Fixed a problem in `\Nijens\OpenapiBundle\Validation\RequestValidator\RequestParameterValidator::validateQueryParameter` where a warning would be triggered if `$parameter` did not have the `required` property. 
2. Normalize booleanish query parameters in RequestParameterValidator