### PR TITLE
fix(route-loader): handle enum path parameters and add regression test

### DIFF
--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -242,7 +242,7 @@ class RouteLoader extends FileLoader
                         '|',
                         array_map(function ($value) {
                             return preg_quote($value, '/');
-                        }, $parameter->enum)
+                        }, $parameterSchema->enum)
                     )
                 );
 

--- a/tests/Resources/specifications/route-loader-enum-path-parameter.yaml
+++ b/tests/Resources/specifications/route-loader-enum-path-parameter.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+
+info:
+  title: OpenAPI bundle enum path parameter test specification
+  version: 0.1.0
+
+paths:
+  /pets/{status}:
+    get:
+      responses:
+        '200':
+          description: Returns a pet status.
+    parameters:
+      - name: status
+        in: path
+        required: true
+        schema:
+          type: string
+          enum:
+            - available
+            - pending
+            - sold

--- a/tests/Routing/RouteLoaderTest.php
+++ b/tests/Routing/RouteLoaderTest.php
@@ -200,6 +200,15 @@ class RouteLoaderTest extends TestCase
         static::assertSame('bar', $route->getDefault('foo'));
     }
 
+    public function testCanLoadRouteWithEnumPathParameterRequirement(): void
+    {
+        $routes = $this->routeLoader->load('route-loader-enum-path-parameter.yaml', 'openapi');
+        $route = $routes->get('pets_status_get');
+
+        static::assertInstanceOf(Route::class, $route);
+        static::assertSame(['status' => '(available|pending|sold)'], $route->getRequirements());
+    }
+
     private function createFileLocator(): FileLocator
     {
         return new FileLocator([


### PR DESCRIPTION
This change fixes RouteLoader so enum-based path parameter requirements are built from the parameter schema enum instead of the parameter object itself.

Added a regression test to verify that a path parameter with schema.enum generates the expected route requirement regex.